### PR TITLE
[ DP - 248 ] 비회원이 접근 할 수 없는 경로 /로 보내기 , 에러 바운더리 수정

### DIFF
--- a/components/common/header.tsx
+++ b/components/common/header.tsx
@@ -24,9 +24,9 @@ export default function Header() {
 
   useEffect(() => {
     if (userInfo.accessToken) {
-      const JWT_TOKEN = userInfo.accessToken;
-
-      JWT_TOKEN ? setLoginStatus() : setLogoutStatus();
+      setLoginStatus();
+    } else {
+      setLogoutStatus();
     }
   }, [userInfo]);
 

--- a/components/common/layout.tsx
+++ b/components/common/layout.tsx
@@ -1,6 +1,9 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 
 import { useRouter } from 'next/router';
+
+import { useLoginStatusStore } from '@stores/loginStore';
+import { useLoginModalStore } from '@stores/modalStore';
 
 import useIsMobile from '@hooks/useIsMobile';
 
@@ -17,8 +20,19 @@ import { AuthModal } from './modals/modal';
 export default function Layout({ children }: { children: ReactNode }) {
   const router = useRouter();
   const { pathname } = router;
-
+  const { loginStatus } = useLoginStatusStore();
+  const { openModal } = useLoginModalStore();
   const isMobile = useIsMobile();
+
+  useEffect(() => {
+    if (
+      loginStatus === 'logout' &&
+      (pathname.startsWith('/myinfo') || pathname === '/pickposting')
+    ) {
+      router.push('/');
+      openModal();
+    }
+  }, [loginStatus, pathname]);
 
   if (pathname === '/loginloading') {
     return <>{children}</>;

--- a/components/common/layout.tsx
+++ b/components/common/layout.tsx
@@ -34,6 +34,10 @@ export default function Layout({ children }: { children: ReactNode }) {
     }
   }, [loginStatus, pathname]);
 
+  if (loginStatus === 'logout' && (pathname.startsWith('/myinfo') || pathname === '/pickposting')) {
+    return null;
+  }
+
   if (pathname === '/loginloading') {
     return <>{children}</>;
   }

--- a/components/common/layout.tsx
+++ b/components/common/layout.tsx
@@ -36,10 +36,6 @@ export default function Layout({ children }: { children: ReactNode }) {
     }
   }, [loginStatus, pathname]);
 
-  if (loginStatus === 'logout' && (pathname.startsWith('/myinfo') || pathname === '/pickposting')) {
-    return null;
-  }
-
   if (pathname === '/loginloading') {
     return <>{children}</>;
   }

--- a/components/common/layout.tsx
+++ b/components/common/layout.tsx
@@ -7,6 +7,8 @@ import { useLoginModalStore } from '@stores/modalStore';
 
 import useIsMobile from '@hooks/useIsMobile';
 
+import QueryErrorBoundary from '@components/common/QueryErrorBoundary';
+
 import { PretendardVariable } from '@/styles/fonts';
 
 import GoToTopButton from './GoToTopButton';
@@ -55,13 +57,15 @@ export default function Layout({ children }: { children: ReactNode }) {
           className={`${PretendardVariable.className}  grid grid-rows-[8.5rem,1fr,5vh] h-screen text-white`}
         >
           <Header />
-          <main className='w-full'>
-            <Toast />
-            <AuthModal />
-            {children}
-            {pathname !== '/' && <GoToTopButton />}
-          </main>
-          <Footer />
+          <QueryErrorBoundary>
+            <main className='w-full'>
+              <Toast />
+              <AuthModal />
+              {children}
+              {pathname !== '/' && <GoToTopButton />}
+            </main>
+            <Footer />
+          </QueryErrorBoundary>
         </div>
       )}
     </>

--- a/pages/404.page.tsx
+++ b/pages/404.page.tsx
@@ -8,10 +8,7 @@ import ArrowLeft from '@public/image/arrow-left-2.svg';
 
 export default function Custom404() {
   return (
-    <div
-      className='flex flex-col items-center'
-      style={{ position: 'fixed', top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }}
-    >
+    <div className='flex flex-col items-center mt-[11.8rem]'>
       <Image src={EmptyImage} alt='404 이미지' />
       <p className='st2 font-bold mt-[4.629rem] mb-[3.2rem]'>헉... 페이지를 찾을 수 없어요.</p>
       <Link href={'/'}>

--- a/pages/_app.page.tsx
+++ b/pages/_app.page.tsx
@@ -11,7 +11,6 @@ import getUserInfoFromLocalStorage from '@utils/getUserInfo';
 
 import { useUserInfoStore } from '@stores/userInfoStore';
 
-import QueryErrorBoundary from '@components/common/QueryErrorBoundary';
 import Layout from '@components/common/layout';
 
 import useSetAxiosConfig from '@/api/useSetAxiosConfig';
@@ -65,15 +64,13 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   }, [router.events]);
 
   return (
-    <QueryErrorBoundary>
-      <QueryClientProvider client={queryClient}>
-        <ThemeProvider enableSystem={false} attribute='class'>
-          <Layout>
-            <Component {...pageProps} />
-          </Layout>
-        </ThemeProvider>
-        <ReactQueryDevtools initialIsOpen={false} />
-      </QueryClientProvider>
-    </QueryErrorBoundary>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider enableSystem={false} attribute='class'>
+        <Layout>
+          <Component {...pageProps} />
+        </Layout>
+      </ThemeProvider>
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
   );
 }

--- a/pages/_error.page.tsx
+++ b/pages/_error.page.tsx
@@ -11,10 +11,7 @@ export default function ErrorPage({ resetErrorBoundary }: { resetErrorBoundary: 
   const router = useRouter();
 
   return (
-    <div
-      className='flex flex-col items-center'
-      style={{ position: 'fixed', top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }}
-    >
+    <div className='flex flex-col items-center mt-[11.8rem]'>
       <Image src={ErrorImage} alt='에러 이미지' />
       <p className='st2 font-bold mt-[4.629rem] mb-[3.2rem]'>
         요청을 처리하는데 실패했어요. 다시 시도해주세요.


### PR DESCRIPTION
- 에러페이지가 헤더 밑에서 보이도록 수정
- 비회원이 접근 불가능한 `path`에 접근시 `/`로 보내고 로그인 모달 띄우기

**[고민]**
- 현재 비회원이 접근 불가능한 path에 접근시 **잠깐 그 페이지가 나오고**  `/`로 리다이렉트 되는데 이 부분을  `next/middleware`로 보안할 수 있다고 하더라구요!  근데 문제는 `/`로 접근시 로그인 모달을 띄우는데 있어서 리다이렉션 된 페이지인지 유저가 처음 접근해서 들어온 페이지인지 구별하는게 까다로울 것 같아서 요거는 이슈 파놓고  주요 기능 처리 후 제가 다시 맡아봐도 될까용! 