### PR TITLE
[DP-249] 회원탈퇴 서베이 다음 버튼 동작 이슈 수정

### DIFF
--- a/pages/myinfo/account-delete/components/CheckReasonBox.tsx
+++ b/pages/myinfo/account-delete/components/CheckReasonBox.tsx
@@ -24,14 +24,15 @@ export default function CheckReasonBox({ id, reason, content }: CheckReasonBoxPr
 
   const [checked, setChecked] = useState(Boolean(initialSurvey));
   const message = initialSurvey?.message || '';
+  const isContent = content == null ? false : true;
 
   useEffect(() => {
     if (checked) {
-      setCheckedSurveyList(id);
+      setCheckedSurveyList(id, isContent);
     } else {
       setUncheckedSurveyList(id);
     }
-  }, [checked, id, setCheckedSurveyList, setUncheckedSurveyList]);
+  }, [checked, id, isContent, setCheckedSurveyList, setUncheckedSurveyList]);
 
   return (
     <label
@@ -57,7 +58,7 @@ export default function CheckReasonBox({ id, reason, content }: CheckReasonBoxPr
           <textarea
             placeholder={content}
             className='bg-black p-[2.4rem] w-full rounded-[1.2rem] resize-none outline-none p2 placeholder:text-gray4 mt-[2.4rem]'
-            onChange={(e) => setCheckedSurveyList(id, e.target.value)}
+            onChange={(e) => setCheckedSurveyList(id, isContent, e.target.value)}
             defaultValue={message}
           />
 

--- a/pages/myinfo/account-delete/index.page.tsx
+++ b/pages/myinfo/account-delete/index.page.tsx
@@ -60,8 +60,11 @@ export default function AccountDelete() {
             }}
             disabled={
               checkedSurveyList.length === 0 ||
-              checkedSurveyList.every((list) => {
-                return list.message === undefined || list.message.length <= DELETE_MESSAGE_COUNT;
+              checkedSurveyList.some((list) => {
+                return (
+                  list.isContent &&
+                  (list.message === undefined || list.message.length <= DELETE_MESSAGE_COUNT)
+                );
               })
             }
           />

--- a/pages/myinfo/account-delete/types/exitSurvey.ts
+++ b/pages/myinfo/account-delete/types/exitSurvey.ts
@@ -20,6 +20,7 @@ export interface ExitSurvey {
 
 export type SurveyOption = {
   id: string;
+  isContent: boolean;
   message?: string;
 };
 

--- a/stores/accountDeleteStore.ts
+++ b/stores/accountDeleteStore.ts
@@ -4,7 +4,7 @@ import { SurveyOption } from '@pages/myinfo/account-delete/types/exitSurvey';
 
 interface SurveyListStoreProps {
   checkedSurveyList: SurveyOption[];
-  setCheckedSurveyList: (id: string, message?: string) => void;
+  setCheckedSurveyList: (id: string, isContent: boolean, message?: string) => void;
   setUncheckedSurveyList: (id: string) => void;
 }
 
@@ -14,12 +14,12 @@ const filteredSurveyList = (list: SurveyOption[], id: string): SurveyOption[] =>
 
 export const useSurveyListStore = create<SurveyListStoreProps>((set) => ({
   checkedSurveyList: [],
-  setCheckedSurveyList: (id: string, message?: string) =>
+  setCheckedSurveyList: (id: string, isContent: boolean, message?: string) =>
     set((state) => {
       const existingIndex = state.checkedSurveyList?.findIndex((item) => item.id === id);
 
       if (existingIndex === -1) {
-        return { checkedSurveyList: [...state.checkedSurveyList, { id }] };
+        return { checkedSurveyList: [...state.checkedSurveyList, { id, isContent }] };
       }
 
       if (message !== undefined) {


### PR DESCRIPTION
## 회원탈퇴 서베이 다음 버튼 동작 이슈 수정했어요!
before) 서베이 선택했을 때에는 다음버튼이 활성화 되지 않고 message를 작성해야 활성화되었음
after) 서베이 선택하거나 message가 포함된 서베이 선택 시에는 message를 작성해야 활성화됨