### PR TITLE
[ DP-257 ]  사용자 로그인 여부 상태값을 관리하는 로직 수정

### DIFF
--- a/components/common/header.tsx
+++ b/components/common/header.tsx
@@ -4,6 +4,8 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
+import getUserInfoFromLocalStorage from '@utils/getUserInfo';
+
 import { useLoginStatusStore } from '@stores/loginStore';
 import { useLoginModalStore } from '@stores/modalStore';
 import { useCompanyIdStore, useSearchKeywordStore } from '@stores/techBlogStore';
@@ -22,13 +24,15 @@ export default function Header() {
   const { setSearchKeyword } = useSearchKeywordStore();
   const { setCompanyId } = useCompanyIdStore();
 
+  // TODO: 로컬스토리지에서 바로 꺼내오는 부분에 대해 리팩토링이 필요함
   useEffect(() => {
-    if (userInfo.accessToken) {
+    const userInfoLocalStorage = getUserInfoFromLocalStorage();
+    if (userInfoLocalStorage?.accessToken) {
       setLoginStatus();
     } else {
       setLogoutStatus();
     }
-  }, [userInfo]);
+  }, []);
 
   const handleClickMyinfo = (tabName: string): void => {
     if (loginStatus === 'login') {


### PR DESCRIPTION
- [슬랙 이슈](https://dreamy-patisiel.slack.com/archives/C076TT1ASNB/p1718719402309909)
- 현재 `getUserInfoFromLocalStorage` 함수를 사용하는 곳은 총 2곳입니다! 
1. `useSetAxiosConfig`에서 첫 렌더링때 api를 호출하는 경우 header에 토큰을 잘 넣어주기 위함
2. `header.tsx`에서 새로고침시 사용자 로그인 여부 상태값를 올바르게 셋팅하기 위함
