### PR TITLE
[ DP - 258 ] 가로스크롤 이슈 해결 , 1440~1920 width값 제한 , 기술블로그 bg값 (gray1)

### DIFF
--- a/components/common/layout.tsx
+++ b/components/common/layout.tsx
@@ -50,7 +50,7 @@ export default function Layout({ children }: { children: ReactNode }) {
         </>
       ) : (
         <div
-          className={`${PretendardVariable.className}  grid grid-rows-[8.5rem,1fr,5vh] h-screen text-white`}
+          className={`${PretendardVariable.className} overflow-x-auto box-border grid grid-rows-[8.5rem,1fr,5vh] h-screen text-white`}
         >
           <Header />
           <AuthModal />

--- a/components/common/layout.tsx
+++ b/components/common/layout.tsx
@@ -55,11 +55,13 @@ export default function Layout({ children }: { children: ReactNode }) {
           <Header />
           <AuthModal />
           <QueryErrorBoundary>
-            <main className='w-full'>
-              <Toast />
-              {children}
-              {pathname !== '/' && <GoToTopButton />}
-            </main>
+            <div className='flex justify-center w-full'>
+              <main className='w-full min-w-[1440px] max-w-[1920px]'>
+                <Toast />
+                {children}
+                {pathname !== '/' && <GoToTopButton />}
+              </main>
+            </div>
             <Footer />
           </QueryErrorBoundary>
         </div>

--- a/components/features/main/dynamicTechBlogComponent.tsx
+++ b/components/features/main/dynamicTechBlogComponent.tsx
@@ -137,6 +137,7 @@ export default function DynamicTechBlogComponent({
                             )}
                           </div>
                           <TechInfo
+                            type='main'
                             author={author}
                             date={regDate}
                             company={company?.name}

--- a/pages/techblog/components/techDetailCard.tsx
+++ b/pages/techblog/components/techDetailCard.tsx
@@ -49,7 +49,7 @@ export default function TechDetailCard({
   return (
     <section className='mb-[9.6rem]'>
       <div className='flex items-center justify-between mb-[4.8rem]'>
-        <Link href='/techblog' className='text-st1 font-bold'>
+        <Link href='/techblog' className='h3 font-bold'>
           기술블로그 🧪
         </Link>
         <SearchInput />

--- a/pages/techblog/components/techSubComponent.tsx
+++ b/pages/techblog/components/techSubComponent.tsx
@@ -73,11 +73,13 @@ export const TechContent = ({
 };
 
 export const TechInfo = ({
+  type = 'tech',
   author,
   date,
   company,
   companyId,
 }: {
+  type?: 'main' | 'tech';
   author: string;
   date: string;
   company: string;
@@ -87,6 +89,7 @@ export const TechInfo = ({
   const { setToastVisible } = useToastVisibleStore();
 
   const handleCompanyClick = () => {
+    if (type === 'main') return;
     setCompanyId(companyId);
     setToastVisible(`‘${company}’에서 제공한 게시물이에요`);
   };
@@ -94,7 +97,10 @@ export const TechInfo = ({
   return (
     <>
       <div className='p2 flex gap-[1.6rem] pb-[0.7rem]'>
-        <p className='text-primary3 font-bold cursor-pointer' onClick={handleCompanyClick}>
+        <p
+          className={`text-primary3 font-bold ${type === 'main' ? '' : 'cursor-pointer'}`}
+          onClick={handleCompanyClick}
+        >
           {company}
         </p>
         <p className='text-gray3'> | </p>


### PR DESCRIPTION
-  1440~1920 width값 제한 [2f37603](https://github.com/dreamyPatisiel/devdevdev-client/pull/82/commits/2f37603bf76e6c399b0a42b36cd316b25bf384d5)
- 가로스크롤 이슈 해결 [b3c189a](https://github.com/dreamyPatisiel/devdevdev-client/pull/82/commits/b3c189a60860c57a45d34977586cfb9f6d7ef6ec)
- `border-box` 은 추후 요소의 크기를 정확하게 조절하거나 레이아웃 예측을 위해 넣어 놨어요!  

- 기술블로그 bg값 (gray1) [de1e607](https://github.com/dreamyPatisiel/devdevdev-client/pull/82/commits/de1e6077f2acfc0f79565481508311d9e874880f)

- 기술블로그 글자 24px로 맞춤 [24e5132](https://github.com/dreamyPatisiel/devdevdev-client/pull/82/commits/24e5132e28df4592971e9c87338a5363de7dc298)

- 메인페이지에서 기업명 클릭시 이벤트 막기[0ca1082](https://github.com/dreamyPatisiel/devdevdev-client/pull/82/commits/0ca1082ea9e4b5e549883adbe694a1dd75014554)