### PR TITLE
[ DP-262 ] 드롭다운 타입 에러 해결 (내정보 북마크 타입과 픽픽픽&기술블로그 타입이 달라 생긴 에러)

### DIFF
--- a/components/common/dropdown.tsx
+++ b/components/common/dropdown.tsx
@@ -21,10 +21,8 @@ export function Dropdown({ type = 'default' }: { type?: 'default' | 'bookmark' }
   const dropdownOptions = type === 'default' ? defaultDropdownOptions : bookmarkDropdownOptions;
 
   useEffect(() => {
-    if (!dropdownOptions.includes(sortOption)) {
-      setSort(dropdownOptions[0] as DropdownOptionProps);
-    }
-  }, [type, dropdownOptions, sortOption, setSort]);
+    setSort(dropdownOptions[0] as DropdownOptionProps);
+  }, []);
 
   const handleOptionSelected = (value: DropdownOptionProps) => () => {
     setSort(value);

--- a/components/common/dropdown.tsx
+++ b/components/common/dropdown.tsx
@@ -6,6 +6,7 @@ import { cn } from '@utils/mergeStyle';
 
 import AngleDown from '@public/image/angle-down.svg';
 
+import { bookmarkDropdownOptions, defaultDropdownOptions } from '@/constants/DropdownOptionArr';
 import { DropdownOptionProps, useDropdownStore, useSelectedStore } from '@/stores/dropdownStore';
 
 export function Dropdown({ type = 'default' }: { type?: 'default' | 'bookmark' }) {
@@ -16,9 +17,6 @@ export function Dropdown({ type = 'default' }: { type?: 'default' | 'bookmark' }
   };
 
   const { sortOption, setSort } = useDropdownStore();
-
-  const defaultDropdownOptions = ['LATEST', 'POPULAR', 'MOST_VIEWED' /*'MOST_COMMENTED'*/];
-  const bookmarkDropdownOptions = ['BOOKMARKED', 'LATEST' /*'MOST_COMMENTED'*/];
 
   const dropdownOptions = type === 'default' ? defaultDropdownOptions : bookmarkDropdownOptions;
 

--- a/components/common/dropdown.tsx
+++ b/components/common/dropdown.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import Image from 'next/image';
 
@@ -21,6 +21,12 @@ export function Dropdown({ type = 'default' }: { type?: 'default' | 'bookmark' }
   const bookmarkDropdownOptions = ['BOOKMARKED', 'LATEST' /*'MOST_COMMENTED'*/];
 
   const dropdownOptions = type === 'default' ? defaultDropdownOptions : bookmarkDropdownOptions;
+
+  useEffect(() => {
+    if (!dropdownOptions.includes(sortOption)) {
+      setSort(dropdownOptions[0] as DropdownOptionProps);
+    }
+  }, [type, dropdownOptions, sortOption, setSort]);
 
   const handleOptionSelected = (value: DropdownOptionProps) => () => {
     setSort(value);

--- a/constants/DropdownOptionArr.ts
+++ b/constants/DropdownOptionArr.ts
@@ -1,0 +1,2 @@
+export const defaultDropdownOptions = ['LATEST', 'POPULAR', 'MOST_VIEWED' /*'MOST_COMMENTED'*/];
+export const bookmarkDropdownOptions = ['BOOKMARKED', 'LATEST' /*'MOST_COMMENTED'*/];

--- a/pages/myinfo/bookmark/api/useInfiniteMyInfoBookmark.ts
+++ b/pages/myinfo/bookmark/api/useInfiniteMyInfoBookmark.ts
@@ -9,6 +9,8 @@ import {
   MyinfoBookmarkDropdownProps,
 } from '@pages/myinfo/bookmark/bookmarkType';
 
+import { bookmarkDropdownOptions } from '@/constants/DropdownOptionArr';
+
 import { TECH_VIEW_SIZE } from '../../../techblog/constants/techBlogConstants';
 
 export const getTechBlogData = async ({ techArticleId, bookmarkSort }: GetMyinfoBookmarkProps) => {
@@ -27,6 +29,8 @@ export const getTechBlogData = async ({ techArticleId, bookmarkSort }: GetMyinfo
 };
 
 export const useInfiniteMyInfoBookmark = (sortOption: MyinfoBookmarkDropdownProps) => {
+  const isValidSortOption = bookmarkDropdownOptions.includes(sortOption);
+
   const {
     data: techBlogData,
     fetchNextPage, // 다음 페이지의 데이터를 가져옴
@@ -38,15 +42,19 @@ export const useInfiniteMyInfoBookmark = (sortOption: MyinfoBookmarkDropdownProp
   } = useInfiniteQuery({
     queryKey: ['techBlogBookmark', sortOption],
     // 데이터를 요청하는데 사용하는 함수
-    queryFn: ({ pageParam }) =>
-      getTechBlogData({
-        techArticleId: pageParam,
-        bookmarkSort: sortOption,
-      }),
-    initialPageParam: '',
+    queryFn: ({ pageParam }) => {
+      if (!isValidSortOption) {
+        return Promise.resolve({ data: { content: [], last: true } });
+      } else {
+        return getTechBlogData({
+          techArticleId: pageParam,
+          bookmarkSort: sortOption,
+        });
+      }
+    },
     // 다음 페이지를 가져오기 위한 파라미터 추출 함수
     // lastPage는 이전페이지에서 반환된 데이터를 받아 다음페이지에 필요한 파라미터를 추출한 데이터
-
+    initialPageParam: '',
     getNextPageParam: (lastPage) => {
       if (lastPage?.data.last) {
         return undefined;

--- a/pages/myinfo/bookmark/api/useInfiniteMyInfoBookmark.ts
+++ b/pages/myinfo/bookmark/api/useInfiniteMyInfoBookmark.ts
@@ -45,12 +45,11 @@ export const useInfiniteMyInfoBookmark = (sortOption: MyinfoBookmarkDropdownProp
     queryFn: ({ pageParam }) => {
       if (!isValidSortOption) {
         return Promise.resolve({ data: { content: [], last: true } });
-      } else {
-        return getTechBlogData({
-          techArticleId: pageParam,
-          bookmarkSort: sortOption,
-        });
       }
+      return getTechBlogData({
+        techArticleId: pageParam,
+        bookmarkSort: sortOption,
+      });
     },
     // 다음 페이지를 가져오기 위한 파라미터 추출 함수
     // lastPage는 이전페이지에서 반환된 데이터를 받아 다음페이지에 필요한 파라미터를 추출한 데이터

--- a/pages/myinfo/bookmark/index.page.tsx
+++ b/pages/myinfo/bookmark/index.page.tsx
@@ -1,18 +1,26 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
+
+import { useQueryClient } from '@tanstack/react-query';
 
 import { useDropdownStore } from '@stores/dropdownStore';
 
 import { Dropdown } from '@components/common/dropdown';
 import DynamicTechBlogComponent from '@components/features/main/dynamicTechBlogComponent';
 
+import { TechInfiniteDataType } from '@/types/infiniteQueryType';
+
 import MyInfo from '../index.page';
 import { useInfiniteMyInfoBookmark } from './api/useInfiniteMyInfoBookmark';
 import { MyinfoBookmarkDropdownProps } from './bookmarkType';
-import {TechInfiniteDataType } from '@/types/infiniteQueryType';
 
 export default function BookMark() {
   const bottomDiv = useRef(null);
   const { sortOption } = useDropdownStore();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    queryClient.invalidateQueries({ queryKey: ['techBlogBookmark'] });
+  }, []);
 
   const data = useInfiniteMyInfoBookmark(
     sortOption as MyinfoBookmarkDropdownProps,

--- a/pages/myinfo/bookmark/index.page.tsx
+++ b/pages/myinfo/bookmark/index.page.tsx
@@ -19,6 +19,7 @@ export default function BookMark() {
   const queryClient = useQueryClient();
 
   useEffect(() => {
+    // TODO: 기술블로그쪽도 invalidateQueries를 설정해주면서 로직을 변경해야함 (2차?!)
     queryClient.invalidateQueries({ queryKey: ['techBlogBookmark'] });
   }, []);
 

--- a/pages/pickpickpick/api/useInfinitePickData.ts
+++ b/pages/pickpickpick/api/useInfinitePickData.ts
@@ -6,6 +6,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { getGA } from '@utils/getCookie';
 
+import { defaultDropdownOptions } from '@/constants/DropdownOptionArr';
 import { DefaultDropdownProps } from '@/stores/dropdownStore';
 import { PageResponse } from '@/types/pageResponse';
 
@@ -26,6 +27,7 @@ export const getPickData = async ({ pageParam, pickSort }: GetPickDataProps) => 
 };
 
 export const useInfinitePickData = (sortOption: DefaultDropdownProps) => {
+  const isValidSortOption = defaultDropdownOptions.includes(sortOption);
   const {
     data: pickData,
     fetchNextPage,
@@ -36,7 +38,14 @@ export const useInfinitePickData = (sortOption: DefaultDropdownProps) => {
     isFetching,
   } = useInfiniteQuery({
     queryKey: ['pickData', sortOption],
-    queryFn: ({ pageParam }) => getPickData({ pageParam, pickSort: sortOption }),
+
+    queryFn: ({ pageParam }) => {
+      if (!isValidSortOption) {
+        return Promise.resolve({ data: { content: [], last: true } });
+      } else {
+        return getPickData({ pageParam, pickSort: sortOption });
+      }
+    },
     initialPageParam: Number.MAX_SAFE_INTEGER,
     getNextPageParam: (lastPage: PageResponse<PickDataProps[]>) => {
       if (lastPage?.data.last) {

--- a/pages/pickpickpick/api/useInfinitePickData.ts
+++ b/pages/pickpickpick/api/useInfinitePickData.ts
@@ -42,9 +42,8 @@ export const useInfinitePickData = (sortOption: DefaultDropdownProps) => {
     queryFn: ({ pageParam }) => {
       if (!isValidSortOption) {
         return Promise.resolve({ data: { content: [], last: true } });
-      } else {
-        return getPickData({ pageParam, pickSort: sortOption });
       }
+      return getPickData({ pageParam, pickSort: sortOption });
     },
     initialPageParam: Number.MAX_SAFE_INTEGER,
     getNextPageParam: (lastPage: PageResponse<PickDataProps[]>) => {

--- a/pages/techblog/api/useInfiniteTechBlog.ts
+++ b/pages/techblog/api/useInfiniteTechBlog.ts
@@ -53,14 +53,13 @@ export const useInfiniteTechBlogData = (
     queryFn: ({ pageParam }) => {
       if (!isValidSortOption) {
         return Promise.resolve({ data: { content: [], last: true } });
-      } else {
-        return getTechBlogData({
-          elasticId: pageParam,
-          pickSort: sortOption,
-          keyword: keyword,
-          companyId: companyId,
-        });
       }
+      return getTechBlogData({
+        elasticId: pageParam,
+        pickSort: sortOption,
+        keyword: keyword,
+        companyId: companyId,
+      });
     },
     initialPageParam: '',
     // 다음 페이지를 가져오기 위한 파라미터 추출 함수

--- a/pages/techblog/api/useInfiniteTechBlog.ts
+++ b/pages/techblog/api/useInfiniteTechBlog.ts
@@ -4,6 +4,7 @@ import { useCallback } from 'react';
 
 import { useInfiniteQuery } from '@tanstack/react-query';
 
+import { defaultDropdownOptions } from '@/constants/DropdownOptionArr';
 import { DefaultDropdownProps } from '@/stores/dropdownStore';
 
 import { TECH_VIEW_SIZE } from '../constants/techBlogConstants';
@@ -36,6 +37,8 @@ export const useInfiniteTechBlogData = (
   keyword?: string,
   companyId?: number,
 ) => {
+  const isValidSortOption = defaultDropdownOptions.includes(sortOption);
+
   const {
     data: techBlogData,
     fetchNextPage, // 다음 페이지의 데이터를 가져옴
@@ -47,13 +50,18 @@ export const useInfiniteTechBlogData = (
   } = useInfiniteQuery({
     queryKey: ['techBlogData', sortOption, keyword, companyId],
     // 데이터를 요청하는데 사용하는 함수
-    queryFn: ({ pageParam }) =>
-      getTechBlogData({
-        elasticId: pageParam,
-        pickSort: sortOption,
-        keyword: keyword,
-        companyId: companyId,
-      }),
+    queryFn: ({ pageParam }) => {
+      if (!isValidSortOption) {
+        return Promise.resolve({ data: { content: [], last: true } });
+      } else {
+        return getTechBlogData({
+          elasticId: pageParam,
+          pickSort: sortOption,
+          keyword: keyword,
+          companyId: companyId,
+        });
+      }
+    },
     initialPageParam: '',
     // 다음 페이지를 가져오기 위한 파라미터 추출 함수
     // lastPage는 이전페이지에서 반환된 데이터를 받아 다음페이지에 필요한 파라미터를 추출한 데이터


### PR DESCRIPTION
오랜 삽질끝에... 😂 


- 타입이 다르면 해당 드롭다운의 첫번째 옵션으로 설정해주는 로직으로 변경했어요 😊
- 옵션 배열을 상수로 빼놨어요 [8f01c8a](https://github.com/dreamyPatisiel/devdevdev-client/pull/86/commits/8f01c8ae8f30d442f2f2b677c37794924bb04a5d)
- 타입이 다를경우 api호출을 할 수 없게 막았어요! [2f235be](https://github.com/dreamyPatisiel/devdevdev-client/pull/86/commits/2f235be811c74a0cbf9edb7702e0282ff8e6edde)
- 현재 기술블로그 메인&상세에서 북마크값이 변화하면 내정보에서 업데이트 되도록 처리했어요 (기술블로그 북마크 리팩토링 할 때 로직 수정 필요! )[a5c2f2d](https://github.com/dreamyPatisiel/devdevdev-client/pull/86/commits/a5c2f2d4b3694ee5e45fc5e19fc8f403f9d90ba7)