### PR TITLE
[DP-365] 모바일 최종 QA 반영

### DIFF
--- a/components/common/Toast.tsx
+++ b/components/common/Toast.tsx
@@ -37,9 +37,7 @@ export default function Toast() {
         exit={{ opacity: 0, scale: 0.5 }}
       >
         <div className='flex items-center justify-center'>
-          <div
-            className={`${isMobile ? 'fixed' : 'fixed right-1/2 translate-x-1/2'} z-10 top-[12rem]`}
-          >
+          <div className={`${isMobile ? 'fixed' : 'fixed right-1/2 translate-x-1/2'} z-10`}>
             <div
               className={`bg-gray1 ${isMobile ? 'px-[2.4rem] c1' : 'px-[4rem] p2'}  py-[1.6rem] rounded-[1.2rem] shadow-[0_2px_10px_0_rgba(0,0,0,0.35)]`}
             >

--- a/components/common/bottomContents/BottomContainer.tsx
+++ b/components/common/bottomContents/BottomContainer.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 
 export default function BottomContainer({
   onClose,
@@ -7,6 +7,14 @@ export default function BottomContainer({
   onClose: () => void;
   children: ReactNode;
 }) {
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, []);
+
   return (
     <div className='fixed z-[70] inset-0'>
       <div className='absolute inset-0 bg-black bg-opacity-50 ' onClick={() => onClose()}>

--- a/components/common/buttons/mobileMainButton.tsx
+++ b/components/common/buttons/mobileMainButton.tsx
@@ -1,5 +1,7 @@
 import { HTMLAttributes, useEffect, useState } from 'react';
 
+import { useScrollDirection } from '@hooks/useScrollDirection';
+
 export interface MobileMainButtonProps extends HTMLAttributes<HTMLButtonElement> {
   text: string;
   disabled?: boolean;
@@ -7,24 +9,12 @@ export interface MobileMainButtonProps extends HTMLAttributes<HTMLButtonElement>
 
 export default function MobileMainButton({ text, onClick, disabled }: MobileMainButtonProps) {
   const [showBottom, setShowBottom] = useState(true);
-
-  const handleScrollEvent = () => {
-    if (window.scrollY === 0) {
-      setShowBottom(true);
-      return;
-    }
-
-    setShowBottom(false);
-  };
-
-  const handleClickEvent = () => {
-    setShowBottom(true);
-  };
+  const scrollDirection = useScrollDirection();
 
   useEffect(() => {
-    window.addEventListener('scroll', handleScrollEvent);
-    window.addEventListener('click', handleClickEvent);
-  }, []);
+    if (scrollDirection === 'up') setShowBottom(true);
+    if (scrollDirection === 'down') setShowBottom(false);
+  }, [scrollDirection]);
 
   if (!showBottom) return <></>;
 

--- a/components/common/mobile/mobileToListButton.tsx
+++ b/components/common/mobile/mobileToListButton.tsx
@@ -3,28 +3,18 @@ import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 
+import { useScrollDirection } from '@hooks/useScrollDirection';
+
 import listDots from '@public/image/list-dots.svg';
 
 export default function MobileToListButton({ route }: { route: string }) {
   const [showBottom, setShowBottom] = useState(true);
-
-  const handleScrollEvent = () => {
-    if (window.scrollY === 0) {
-      setShowBottom(true);
-      return;
-    }
-
-    setShowBottom(false);
-  };
-
-  const handleClickEvent = () => {
-    setShowBottom(true);
-  };
+  const scrollDirection = useScrollDirection();
 
   useEffect(() => {
-    window.addEventListener('scroll', handleScrollEvent);
-    window.addEventListener('click', handleClickEvent);
-  }, []);
+    if (scrollDirection === 'up') setShowBottom(true);
+    if (scrollDirection === 'down') setShowBottom(false);
+  }, [scrollDirection]);
 
   if (!showBottom) return <></>;
 

--- a/components/features/main/dynamicTechBlogComponent.tsx
+++ b/components/features/main/dynamicTechBlogComponent.tsx
@@ -62,13 +62,13 @@ export default function DynamicTechBlogComponent({
               {techBlogData?.pages?.map((group, index) => (
                 <React.Fragment key={index}>
                   {group?.data.content.map((data: TechCardProps) => (
-                    <>
+                    <React.Fragment key={data.id}>
                       {isMobile ? (
-                        <DynamicTechCard key={data.id} techData={data} type={type} />
+                        <DynamicTechCard techData={data} type={type} />
                       ) : (
-                        <DesktopMainTechCard key={data.id} techData={data} type={type} />
+                        <DesktopMainTechCard techData={data} type={type} />
                       )}
-                    </>
+                    </React.Fragment>
                   ))}
                 </React.Fragment>
               ))}

--- a/components/features/pickpickpick/PickCard.tsx
+++ b/components/features/pickpickpick/PickCard.tsx
@@ -134,8 +134,8 @@ export default function PickCard({
 
   const PickCardContainerStyle = {
     base: 'border-solid flex flex-col gap-[2.2rem]',
-    mobile: 'my-[3.2rem] mx-[1.6rem] border-t-[0.1rem] border-b-[0.1rem] border-gray1',
-    desktop: 'p-[4rem] border-[0.1rem] rounded-[1.6rem] border-gray3 ',
+    mobile: 'mx-[1.6rem] border-t-[0.1rem] border-b-[0.1rem] border-gray1',
+    desktop: 'p-[4rem] border-[0.1rem] rounded-[1.6rem] border-gray3',
   };
 
   const PickOptionInputStyle = {

--- a/components/features/pickpickpick/PickForm.tsx
+++ b/components/features/pickpickpick/PickForm.tsx
@@ -114,9 +114,9 @@ export default function PickForm({
         <LeftArrowIcon height={`${isMobile && '16'}`} />
       </Link>
 
-      <form onSubmit={handleSubmit(handleSubmitFn)}>
+      <form onSubmit={handleSubmit(handleSubmitFn)} className={`flex flex-col gap-[4rem]`}>
         <div
-          className={`flex gap-[2.4rem] items-baseline relative ${isMobile ? 'px-[1.6rem] ' : 'mt-[2.4rem]'}`}
+          className={`flex items-baseline relative ${isMobile ? 'px-[1.6rem] ' : 'mt-[2.4rem]'}`}
         >
           <Controller
             name='pickTitle'

--- a/hooks/useScrollDirection.ts
+++ b/hooks/useScrollDirection.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+export const useScrollDirection = () => {
+  const [scrollDirection, setScrollDirection] = useState<'up' | 'down'>('up');
+  let preScroll = 0;
+
+  const handleScrollEvent = () => {
+    if (window.scrollY < preScroll) {
+      setScrollDirection('up');
+    }
+
+    if (window.scrollY > preScroll) {
+      setScrollDirection('down');
+    }
+
+    preScroll = window.scrollY;
+  };
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScrollEvent);
+  }, []);
+
+  return scrollDirection;
+};

--- a/pages/myinfo/account-delete/index.page.tsx
+++ b/pages/myinfo/account-delete/index.page.tsx
@@ -80,7 +80,7 @@ export default function AccountDelete() {
               checkedSurveyList.some((list) => {
                 return (
                   list.isContent &&
-                  (list.message === undefined || list.message.length <= DELETE_MESSAGE_COUNT)
+                  (list.message === undefined || list.message.length < DELETE_MESSAGE_COUNT)
                 );
               })
             }

--- a/pages/pickpickpick/[id]/components/VoteButton.tsx
+++ b/pages/pickpickpick/[id]/components/VoteButton.tsx
@@ -72,7 +72,7 @@ export default function VoteButton({ pickOptionData, dataIsVoted }: VoteButtonPr
 
   return (
     <motion.button
-      whileHover={{ scale: 1.1 }}
+      whileHover={isMoblie ? '' : { scale: 1.1 }}
       whileTap={{ scale: 0.9 }}
       onClick={handleVote}
       className={votebuttonClass}


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
- [x] 픽픽픽 투표 시 애니메이션 없애기 - [스레드](https://dreamy-patisiel.slack.com/archives/C0673T3JFJM/p1724055301921049) ([feat: 모바일 픽픽픽 호버 시 애니메이션 적용 안함](https://github.com/dreamyPatisiel/devdevdev-client/pull/148/commits/b7a91d6374a031f8212dc94f1a7fd2e02b3cad3c))

- [x] 하단 버튼 위로스크롤 - 생김, 아래스크롤 - 없어짐 ([feat: 하단 버튼 스크롤 위치 커스텀 훅 구현, 적용](https://github.com/dreamyPatisiel/devdevdev-client/pull/148/commits/5868608cbbac16bc9f979f1e7c5d1ba5ef1f21f2))

- [x] 회원탈퇴 설문 마지막 질문에서 10글자 이상인데, 10글자를 입력하면 다음 버튼 활성화가 되지 않고 있어요. ([fix: 회원탈퇴 다음 버튼 활성화 수정](https://github.com/dreamyPatisiel/devdevdev-client/pull/148/commits/e1bf40740e8f7b844babbf0690bbe11159ffa941)) 

- [x] 정렬에 사용되는 하단 바 노출이 이상해요. (iOS safeArea) [참고자료](https://velog.io/@upkjs07/CSS-iOS-safeArea-%EB%8B%A4%EB%A3%A8%EA%B8%B0) => 스크롤 막기로 수정 ([feat: BottomContainer - 스크롤 방지 추가](https://github.com/dreamyPatisiel/devdevdev-client/pull/148/commits/78c1250971dadee8ba1334f418e4adb1b1bea375))

- [x] 토스트 위치 수정 ([fix: 토스트 위치 수정](https://github.com/dreamyPatisiel/devdevdev-client/pull/148/commits/5318b95fdea90cdec3f1c746866d0a55e8804f43))

- [x] DynamicTechBlogComponent에서 key 관련 에러 수정했어요 ([fix: DynamicTechBlogComponent key 에러 수정](https://github.com/dreamyPatisiel/devdevdev-client/pull/148/commits/faf7210678631f6c000fa78765be0dada405e513))

## 🔗 참고할만한 자료(선택)
> 슬랙이나 피그마, Jira 등 참고 링크를 첨부해주세요
- [슬랙 QA 캔버스](https://dreamy-patisiel.slack.com/canvas/C076TT1ASNB)
