### PR TITLE
[ DP-416] 기술블로그 댓글 모바일 작업

### DIFF
--- a/components/common/buttons/types/subButtons.ts
+++ b/components/common/buttons/types/subButtons.ts
@@ -12,7 +12,7 @@ export interface SubButtonProps
   extends HTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof SubButtonVariants> {
   text: string;
-  variant: 'primary' | 'gray' | 'black';
+  variant: 'primary' | 'primary_border' | 'gray' | 'black';
   disabled?: boolean;
 }
 

--- a/components/common/buttons/variants/subButtons.ts
+++ b/components/common/buttons/variants/subButtons.ts
@@ -6,6 +6,7 @@ export const SubButtonVariants = cva(
     variants: {
       variant: {
         primary: 'bg-primary1 disabled:bg-primary5 disabled:text-primary3 hover:bg-primary2',
+        primary_border: 'border border-[#A448FF] text-[#BD79FF] font-bold',
         gray: 'bg-gray3 disabled:bg-gray3 disabled:text-gray4 hover:bg-gray4',
         black: 'bg-black disabled:text-gray4 hover:bg-gray1 hover:text-gray5',
       },

--- a/components/common/comment/WritableComment.tsx
+++ b/components/common/comment/WritableComment.tsx
@@ -118,6 +118,24 @@ export default function WritableComment({
     }
   };
 
+  const [updatedClassNames, setUpdatedClassNames] = useState({
+    bottomSection: '',
+    buttonContainer: '',
+  });
+
+  useEffect(() => {
+    setUpdatedClassNames({
+      bottomSection: `flex items-end ${
+        isMobile && type === 'pickpickpick'
+          ? 'flex-col gap-[0.8rem]'
+          : 'mt-[1.6rem] justify-between'
+      }`,
+      buttonContainer: `w-full flex gap-[1.6rem] items-center ${
+        isMobile && type === 'pickpickpick' ? 'justify-between' : 'justify-end'
+      }`,
+    });
+  }, [isMobile, type]);
+
   return (
     <div className='px-[2.4rem] py-[1.6rem] bg-[#1A1B23] rounded-[1.6rem]'>
       {!textValue && mode === 'register' && !parentCommentAuthor && (
@@ -157,11 +175,11 @@ export default function WritableComment({
         </span>
       </div>
 
-      <div className='flex justify-between items-end mt-[1.6rem]'>
+      <div className={updatedClassNames.bottomSection}>
         <div className='p2 font-light text-gray4'>
           {textCount}/{MAX_LENGTH}
         </div>
-        <div className='flex items-end gap-[1.6rem]'>
+        <div className={updatedClassNames.buttonContainer}>
           {mode === 'edit' && (
             <SubButton text='취소' variant='primary_border' onClick={handleCancle} />
           )}

--- a/components/common/comment/WritableComment.tsx
+++ b/components/common/comment/WritableComment.tsx
@@ -140,7 +140,7 @@ export default function WritableComment({
     <div className='px-[2.4rem] py-[1.6rem] bg-[#1A1B23] rounded-[1.6rem]'>
       {/* [DP- 395] 에있는 custom-scrollbar로 스타일 변경 필요 */}
       <div
-        className={`p2 px-[1rem] py-[1rem] w-full resize-none outline-none min-h-[6.8rem] ${isMobile ? 'max-h-[12rem]' : 'max-h-[28rem]'} overflow-y-scroll`}
+        className={`p2 px-[1rem] py-[1rem] w-full resize-none outline-none min-h-[6.8rem] ${isMobile ? 'max-h-[12rem]' : 'max-h-[28rem]'} overflow-y-scroll scrollbar-hide`}
       >
         {!textValue && mode === 'register' && !parentCommentAuthor && (
           <span

--- a/components/common/comment/WritableComment.tsx
+++ b/components/common/comment/WritableComment.tsx
@@ -155,7 +155,7 @@ export default function WritableComment({
 
       {/* [DP- 395] 에있는 custom-scrollbar로 스타일 변경 필요 */}
       <div
-        className={`p2 h-[6.4rem] overflow-y-scroll placeholder:text-gray4 px-[1rem] py-[1rem] w-full resize-none outline-none`}
+        className={`p2 px-[1rem] py-[1rem] w-full resize-none outline-none min-h-[6.8rem] ${isMobile ? 'max-h-[12rem]' : 'max-h-[28rem]'} overflow-y-scroll`}
       >
         <span
           contentEditable='false'
@@ -169,7 +169,7 @@ export default function WritableComment({
           ref={editableSpanRef}
           contentEditable='true'
           onInput={handleTextOnInput}
-          className={`p2 placeholder:text-gray4 px-[1rem] py-[1rem] w-full resize-none outline-none min-h-[6.8rem] max-h-[28rem] overflow-y-scroll`}
+          className={`w-full px-[1rem] py-[1rem] resize-none outline-none`}
         >
           {mode === 'register' ? '' : preContents}
         </span>

--- a/components/common/comment/WritableComment.tsx
+++ b/components/common/comment/WritableComment.tsx
@@ -3,6 +3,8 @@ import { useEffect, useRef, useState } from 'react';
 import { useLoginStatusStore } from '@stores/loginStore';
 import { useLoginModalStore } from '@stores/modalStore';
 
+import useIsMobile from '@hooks/useIsMobile';
+
 import { SubButton } from '@components/common/buttons/subButtons';
 
 import VisibilityPickToggle from './VisibilityPickToggle';
@@ -35,6 +37,8 @@ export default function WritableComment({
   parentCommentAuthor,
 }: WritableCommentProps) {
   const MAX_LENGTH = 1000;
+  const isMobile = useIsMobile();
+
   const [textCount, setTextCount] = useState(0);
   const [textValue, setTextValue] = useState('');
   const [isChecked, setIsChecked] = useState(false);
@@ -107,7 +111,10 @@ export default function WritableComment({
   return (
     <div className='px-[2.4rem] py-[1.6rem] bg-[#1A1B23] rounded-[1.6rem]'>
       {!textValue && mode === 'register' && !parentCommentAuthor && (
-        <span className='p2 text-[#677485] absolute ml-7 mt-5' onClick={handleFocus}>
+        <span
+          className={`p2 text-[#677485] absolute w-full ${isMobile ? 'pr-44' : 'ml-7 mt-8'}`}
+          onClick={handleFocus}
+        >
           댑댑이들의 의견을 남겨주세요! 광고 혹은 도배글을 작성할 시에는 관리자 권한으로 삭제할 수
           있습니다.
           {type === 'pickpickpick' && (

--- a/components/common/comment/WritableComment.tsx
+++ b/components/common/comment/WritableComment.tsx
@@ -140,7 +140,7 @@ export default function WritableComment({
     <div className='px-[2.4rem] py-[1.6rem] bg-[#1A1B23] rounded-[1.6rem]'>
       {/* [DP- 395] 에있는 custom-scrollbar로 스타일 변경 필요 */}
       <div
-        className={`p2 px-[1rem] py-[1rem] w-full resize-none outline-none min-h-[6.8rem] ${isMobile ? 'max-h-[12rem]' : 'max-h-[28rem]'} overflow-y-scroll scrollbar-hide`}
+        className={`p2 pr-[1rem] py-[1rem] w-full resize-none outline-none min-h-[6.8rem] ${isMobile ? 'max-h-[12rem]' : 'max-h-[28rem]'} overflow-y-scroll scrollbar-hide`}
       >
         {!textValue && mode === 'register' && !parentCommentAuthor && (
           <span

--- a/components/common/comment/WritableComment.tsx
+++ b/components/common/comment/WritableComment.tsx
@@ -24,7 +24,7 @@ interface WritableCommentProps {
     isPickVotePublic?: boolean;
     onSuccess: () => void;
   }) => void;
-  cancleButtonClick: () => void;
+  cancleButtonClick?: () => void;
   parentCommentAuthor?: string;
 }
 

--- a/components/common/comment/WritableComment.tsx
+++ b/components/common/comment/WritableComment.tsx
@@ -140,7 +140,7 @@ export default function WritableComment({
     <div className='px-[2.4rem] py-[1.6rem] bg-[#1A1B23] rounded-[1.6rem]'>
       {!textValue && mode === 'register' && !parentCommentAuthor && (
         <span
-          className={`p2 text-[#677485] absolute w-full ${isMobile ? 'pr-44' : 'ml-7 mt-8'}`}
+          className={`p2 text-[#677485] absolute ${isMobile ? 'pr-[5.6rem]' : 'ml-7 mt-8'}`}
           onClick={handleFocus}
         >
           댑댑이들의 의견을 남겨주세요! 광고 혹은 도배글을 작성할 시에는 관리자 권한으로 삭제할 수

--- a/components/common/comment/WritableComment.tsx
+++ b/components/common/comment/WritableComment.tsx
@@ -24,6 +24,7 @@ interface WritableCommentProps {
     isPickVotePublic?: boolean;
     onSuccess: () => void;
   }) => void;
+  cancleButtonClick: () => void;
   parentCommentAuthor?: string;
 }
 
@@ -34,6 +35,7 @@ export default function WritableComment({
   preContents,
   isVoted = true,
   writableCommentButtonClick,
+  cancleButtonClick,
   parentCommentAuthor,
 }: WritableCommentProps) {
   const MAX_LENGTH = 1000;
@@ -95,6 +97,17 @@ export default function WritableComment({
         setTextCount(0);
       },
     });
+  };
+
+  const handleCancle = () => {
+    if (cancleButtonClick) {
+      cancleButtonClick();
+    }
+    if (editableSpanRef.current) {
+      editableSpanRef.current.innerText = '';
+    }
+    setTextValue('');
+    setTextCount(0);
   };
 
   /** 비회원이 댓글 작성시도시 로그인모달 띄우기 */
@@ -173,8 +186,11 @@ export default function WritableComment({
         </div>
         <div className='flex items-end gap-[1.6rem]'>
           {type === 'pickpickpick' && <VisibilityPickToggle />}
+          {mode === 'edit' && (
+            <SubButton text='취소' variant='primary_border' onClick={handleCancle} />
+          )}
           <SubButton
-            text={mode === 'register' ? '댓글 남기기' : '댓글 수정하기'}
+            text={mode === 'register' ? '댓글 남기기' : '수정하기'}
             variant='primary'
             disabled={textCount <= 0}
             onClick={handleSubmitWritable}

--- a/components/common/comment/WritableComment.tsx
+++ b/components/common/comment/WritableComment.tsx
@@ -96,7 +96,7 @@ export default function WritableComment({
     });
   };
 
-  const handleCancle = () => {
+  const handleCancel = () => {
     if (cancleButtonClick) {
       cancleButtonClick();
     }
@@ -181,7 +181,7 @@ export default function WritableComment({
         </div>
         <div className={updatedClassNames.buttonContainer}>
           {mode === 'edit' && (
-            <SubButton text='취소' variant='primary_border' onClick={handleCancle} />
+            <SubButton text='취소' variant='primary_border' onClick={handleCancel} />
           )}
           {type === 'pickpickpick' && (
             <VisibilityPickToggle

--- a/components/common/comment/WritableComment.tsx
+++ b/components/common/comment/WritableComment.tsx
@@ -24,7 +24,7 @@ interface WritableCommentProps {
     isPickVotePublic?: boolean;
     onSuccess: () => void;
   }) => void;
-  cancleButtonClick?: () => void;
+  cancelButtonClick?: () => void;
   parentCommentAuthor?: string;
 }
 
@@ -35,7 +35,7 @@ export default function WritableComment({
   preContents,
   isVoted = true,
   writableCommentButtonClick,
-  cancleButtonClick,
+  cancelButtonClick,
   parentCommentAuthor,
 }: WritableCommentProps) {
   const MAX_LENGTH = 1000;
@@ -97,8 +97,8 @@ export default function WritableComment({
   };
 
   const handleCancel = () => {
-    if (cancleButtonClick) {
-      cancleButtonClick();
+    if (cancelButtonClick) {
+      cancelButtonClick();
     }
     if (editableSpanRef.current) {
       editableSpanRef.current.innerText = '';

--- a/components/common/comment/WritableComment.tsx
+++ b/components/common/comment/WritableComment.tsx
@@ -138,25 +138,24 @@ export default function WritableComment({
 
   return (
     <div className='px-[2.4rem] py-[1.6rem] bg-[#1A1B23] rounded-[1.6rem]'>
-      {!textValue && mode === 'register' && !parentCommentAuthor && (
-        <span
-          className={`p2 text-[#677485] absolute ${isMobile ? 'pr-[5.6rem]' : 'ml-7 mt-8'}`}
-          onClick={handleFocus}
-        >
-          댑댑이들의 의견을 남겨주세요! 광고 혹은 도배글을 작성할 시에는 관리자 권한으로 삭제할 수
-          있습니다.
-          {type === 'pickpickpick' && (
-            <>
-              <br /> 픽픽픽 공개여부는 댓글을 작성하고 나면 수정할 수 없어요.
-            </>
-          )}
-        </span>
-      )}
-
       {/* [DP- 395] 에있는 custom-scrollbar로 스타일 변경 필요 */}
       <div
         className={`p2 px-[1rem] py-[1rem] w-full resize-none outline-none min-h-[6.8rem] ${isMobile ? 'max-h-[12rem]' : 'max-h-[28rem]'} overflow-y-scroll`}
       >
+        {!textValue && mode === 'register' && !parentCommentAuthor && (
+          <span
+            className={`p2 text-[#677485] absolute ${isMobile ? 'pr-[5.6rem]' : ''}`}
+            onClick={handleFocus}
+          >
+            댑댑이들의 의견을 남겨주세요! 광고 혹은 도배글을 작성할 시에는 관리자 권한으로 삭제할 수
+            있습니다.
+            {type === 'pickpickpick' && (
+              <>
+                <br /> 픽픽픽 공개여부는 댓글을 작성하고 나면 수정할 수 없어요.
+              </>
+            )}
+          </span>
+        )}
         <span
           contentEditable='false'
           suppressContentEditableWarning={true}
@@ -169,7 +168,7 @@ export default function WritableComment({
           ref={editableSpanRef}
           contentEditable='true'
           onInput={handleTextOnInput}
-          className={`w-full px-[1rem] py-[1rem] resize-none outline-none`}
+          className={`w-full resize-none outline-none`}
         >
           {mode === 'register' ? '' : preContents}
         </span>

--- a/components/common/comment/WritableComment.tsx
+++ b/components/common/comment/WritableComment.tsx
@@ -137,14 +137,16 @@ export default function WritableComment({
   }, [isMobile, type]);
 
   return (
-    <div className='px-[2.4rem] py-[1.6rem] bg-[#1A1B23] rounded-[1.6rem]'>
+    <div
+      className={`${isMobile ? 'px-[1.6rem]' : 'px-[2.4rem]'}  py-[1.6rem] bg-[#1A1B23] rounded-[1.6rem]`}
+    >
       {/* [DP- 395] 에있는 custom-scrollbar로 스타일 변경 필요 */}
       <div
-        className={`p2 pr-[1rem] py-[1rem] w-full resize-none outline-none min-h-[6.8rem] ${isMobile ? 'max-h-[12rem]' : 'max-h-[28rem]'} overflow-y-scroll scrollbar-hide`}
+        className={`p2 w-full resize-none outline-none ${isMobile ? 'max-h-[12rem] min-h-[9.6rem]' : 'max-h-[28rem] min-h-[6.8rem]'} overflow-y-scroll scrollbar-hide`}
       >
         {!textValue && mode === 'register' && !parentCommentAuthor && (
           <span
-            className={`p2 text-[#677485] absolute ${isMobile ? 'pr-[5.6rem]' : ''}`}
+            className={`p2 text-[#677485] absolute ${isMobile ? 'pr-[3.2rem]' : ''}`}
             onClick={handleFocus}
           >
             댑댑이들의 의견을 남겨주세요! 광고 혹은 도배글을 작성할 시에는 관리자 권한으로 삭제할 수

--- a/components/common/dropdowns/mobileDropdown.tsx
+++ b/components/common/dropdowns/mobileDropdown.tsx
@@ -10,6 +10,7 @@ import { DropdownOptionProps, useDropdownStore } from '@stores/dropdownStore';
 import AngleDown from '@public/image/dropdown-angle-down.svg';
 
 import {
+  TechBlogCommentsOptions,
   bookmarkDropdownOptions,
   pickpickpickDropdownOptions,
   techBlogDropdownOptions,
@@ -20,7 +21,7 @@ import BottomContainer from '../bottomContents/BottomContainer';
 export default function MobileDropdown({
   type = 'pickpickpick',
 }: {
-  type?: 'pickpickpick' | 'techblog' | 'bookmark';
+  type?: 'pickpickpick' | 'techblog' | 'bookmark' | 'comment';
 }) {
   const [showBottom, setShowBottom] = useState(false);
 
@@ -37,6 +38,8 @@ export default function MobileDropdown({
       break;
     case 'bookmark':
       dropdownOptions = bookmarkDropdownOptions;
+    case 'comment':
+      dropdownOptions = TechBlogCommentsOptions;
       break;
   }
 

--- a/pages/pickpickpick/[id]/components/Comment.tsx
+++ b/pages/pickpickpick/[id]/components/Comment.tsx
@@ -172,7 +172,7 @@ export default function Comment({
 
   const moreButtonList = isCommentAuthor ? commentAuthorButtonList : otherCommentAuthorButtonList;
 
-  const handleCancleButtonClick = () => {
+  const handleCancelButtonClick = () => {
     setIsEditActived(false);
   };
 
@@ -245,7 +245,7 @@ export default function Comment({
           }
           parentCommentAuthor={type === 'reply' && isReplyActived ? author : ''}
           preContents={preContents}
-          cancleButtonClick={handleCancleButtonClick}
+          cancleButtonClick={handleCancelButtonClick}
         />
       )}
     </div>

--- a/pages/pickpickpick/[id]/components/Comment.tsx
+++ b/pages/pickpickpick/[id]/components/Comment.tsx
@@ -245,7 +245,7 @@ export default function Comment({
           }
           parentCommentAuthor={type === 'reply' && isReplyActived ? author : ''}
           preContents={preContents}
-          cancleButtonClick={handleCancelButtonClick}
+          cancelButtonClick={handleCancelButtonClick}
         />
       )}
     </div>

--- a/pages/pickpickpick/[id]/components/Comment.tsx
+++ b/pages/pickpickpick/[id]/components/Comment.tsx
@@ -172,6 +172,10 @@ export default function Comment({
 
   const moreButtonList = isCommentAuthor ? commentAuthorButtonList : otherCommentAuthorButtonList;
 
+  const handleCancleButtonClick = () => {
+    setIsEditActived(false);
+  };
+
   return (
     <div
       className={`flex flex-col gap-[2.4rem] pt-[2.4rem] pb-[3.2rem] border-b-[0.1rem] border-b-gray3 border-t-[0.1rem] border-t-gray3 ${isSubComment && 'bg-gray1 px-[3.2rem]'}`}
@@ -241,6 +245,7 @@ export default function Comment({
           }
           parentCommentAuthor={type === 'reply' && isReplyActived ? author : ''}
           preContents={preContents}
+          cancleButtonClick={handleCancleButtonClick}
         />
       )}
     </div>

--- a/pages/techblog/components/Comment.tsx
+++ b/pages/techblog/components/Comment.tsx
@@ -142,7 +142,7 @@ export default function Comment({
     );
   };
 
-  const handleCancleButtonClick = () => {
+  const handleCancelButtonClick = () => {
     setIsEditMode(false);
   };
 
@@ -176,7 +176,7 @@ export default function Comment({
             preContents={comment}
             parentCommentAuthor={techParentCommentAuthor}
             writableCommentButtonClick={handleEditBtnClick}
-            cancleButtonClick={handleCancleButtonClick}
+            cancleButtonClick={handleCancelButtonClick}
           />
         )}
         <CommentActionButtons

--- a/pages/techblog/components/Comment.tsx
+++ b/pages/techblog/components/Comment.tsx
@@ -176,7 +176,7 @@ export default function Comment({
             preContents={comment}
             parentCommentAuthor={techParentCommentAuthor}
             writableCommentButtonClick={handleEditBtnClick}
-            cancleButtonClick={handleCancelButtonClick}
+            cancelButtonClick={handleCancelButtonClick}
           />
         )}
         <CommentActionButtons

--- a/pages/techblog/components/Comment.tsx
+++ b/pages/techblog/components/Comment.tsx
@@ -142,6 +142,10 @@ export default function Comment({
     );
   };
 
+  const handleCancleButtonClick = () => {
+    setIsEditMode(false);
+  };
+
   return (
     <>
       <div
@@ -172,6 +176,7 @@ export default function Comment({
             preContents={comment}
             parentCommentAuthor={techParentCommentAuthor}
             writableCommentButtonClick={handleEditBtnClick}
+            cancleButtonClick={handleCancleButtonClick}
           />
         )}
         <CommentActionButtons

--- a/pages/techblog/components/CommentReplies.tsx
+++ b/pages/techblog/components/CommentReplies.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 
 import Image from 'next/image';
 
+import useIsMobile from '@hooks/useIsMobile';
+
 import downArrow from '@public/image/down-arrow-green.svg';
 import upArrow from '@public/image/up-arrow-green.svg';
 
@@ -17,6 +19,7 @@ export default function CommentReplies({
   articleId: number;
   originParentTechCommentId: number;
 }) {
+  const isMobile = useIsMobile();
   const repliesLen = replies?.length;
 
   // TODO: 접었을때 댓글더보기가 사라져야하는데 안사라짐.. 수정필요
@@ -63,7 +66,7 @@ export default function CommentReplies({
       {/* 댓글 접기&열기 버튼 */}
       {repliesLen > 0 && (
         <button
-          className='w-full flex items-center ml-[3.2rem] gap-3 p2 font-bold text-point1 h-[5.6rem]'
+          className={`w-full flex items-center gap-3 p2 font-bold text-point1 h-[5.6rem] ${isMobile ? 'ml-[1.6rem]' : 'ml-[3.2rem]'}  `}
           onClick={handleOpenComments}
         >
           {`댓글 ${repliesLen}개`}

--- a/pages/techblog/components/CommentTechSection.tsx
+++ b/pages/techblog/components/CommentTechSection.tsx
@@ -6,9 +6,11 @@ import { InfiniteData } from '@tanstack/react-query';
 
 import { useDropdownStore } from '@stores/dropdownStore';
 
+import useIsMobile from '@hooks/useIsMobile';
 import { useObserver } from '@hooks/useObserver';
 
 import { Dropdown } from '@components/common/dropdowns/dropdown';
+import MobileDropdown from '@components/common/dropdowns/mobileDropdown';
 import { TechSkeletonList } from '@components/common/skeleton/techBlogSkeleton';
 
 import { useInfiniteTechBlogComments } from '../api/useInfiniteGetTechComments';
@@ -17,6 +19,7 @@ import { TechBlogCommentsDropdownProps, TechCommentProps } from '../types/techCo
 const DynamicTechCommentSet = dynamic(() => import('@/pages/techblog/components/CommentSet'));
 
 export default function CommentTechSection({ articleId }: { articleId: string }) {
+  const isMobile = useIsMobile();
   const { sortOption } = useDropdownStore();
 
   const bottomDiv = useRef(null);
@@ -81,7 +84,7 @@ export default function CommentTechSection({ articleId }: { articleId: string })
         <p className='p1'>
           <span className='text-point3'>{totalCommentCnt}</span>개의 댓글
         </p>
-        <Dropdown type='techComment' />
+        {isMobile ? <MobileDropdown type='comment' /> : <Dropdown type='techComment' />}
       </div>
 
       {totalCommentCnt === 0 && (

--- a/pages/techblog/components/techDetailCard.tsx
+++ b/pages/techblog/components/techDetailCard.tsx
@@ -18,7 +18,7 @@ import { ROUTES } from '@/constants/routes';
 
 import { TechCardProps } from '../types/techBlogType';
 import {
-  ArticleViewBtn,
+  ArticleViewRoundButton,
   TechBookMarkAndToolTip,
   TechDetailInfo,
   TechMainContent,
@@ -126,17 +126,13 @@ export default function TechDetailCard({
           )}
         </div>
       </div>
+      {isMobile && <ArticleViewRoundButton margin='mt-[3.2rem]' techArticleUrl={techArticleUrl} />}
 
       <div className={`${isMobile ? 'px-[1.6rem]' : 'px-[4rem] mt-20'}`}>
         <TechMainContent isMobile={isMobile} content={contents} />
       </div>
-      <div className={`${isMobile ? '' : 'px-[14.5rem]'}`}>
-        <ArticleViewBtn
-          paddingY={isMobile ? 'pt-[0.9rem]' : 'pt-[6.4rem]'}
-          fontSize={isMobile ? 'st2' : 'st1'}
-          techArticleUrl={techArticleUrl}
-        />
-      </div>
+
+      {!isMobile && <ArticleViewRoundButton techArticleUrl={techArticleUrl} />}
       <div className={`border-b border-b-gray1 ${isMobile ? 'mx-[1.6rem]' : 'mx-[4rem]'}`} />
     </section>
   );

--- a/pages/techblog/components/techDetailCardSubComponent.tsx
+++ b/pages/techblog/components/techDetailCardSubComponent.tsx
@@ -43,13 +43,14 @@ export const TechMainContent = ({ content, isMobile }: { content: string; isMobi
     <EllipsisGradientText
       startPercent='60%'
       endPercent='100%'
-      className={`${isMobile ? 'p2 my-[5.6rem]' : 'p1 py-[1.7rem]'} `}
+      className={`${isMobile ? 'p2 my-[2.4rem]' : 'p1 py-[1.7rem]'} `}
     >
       {content}
     </EllipsisGradientText>
   );
 };
 
+/** 1차 아티클전체보기 버튼스타일 */
 export const ArticleViewBtn = ({
   techArticleUrl,
   fontSize = 'st1',
@@ -71,6 +72,26 @@ export const ArticleViewBtn = ({
         <p className={`${textIconGap}`}>아티클 전체 보기</p>
       </Link>
       <Image src={RightArrow} alt='오른쪽화살표' className={`text-point1 ${iconSize}`} />
+    </button>
+  );
+};
+
+/** 2차 아티클전체보기 버튼 */
+
+export const ArticleViewRoundButton = ({
+  techArticleUrl,
+  fontSize = 'p1',
+  margin = 'mt-[8.1rem] mb-[4.8rem]', // 웹기준 기본 스타일링
+}: {
+  techArticleUrl: string;
+  fontSize?: string;
+  margin?: string;
+}) => {
+  return (
+    <button
+      className={`block mx-auto text-center px-8 py-4 border border-[#40FF81] text-[#40FF81] rounded-full ${fontSize} font-bold ${margin}`}
+    >
+      <Link href={techArticleUrl}>아티클 전체보기</Link>
     </button>
   );
 };


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
- [x] [기술블로그 - 댓글더보기 버튼 모바일 스타일링](https://github.com/dreamyPatisiel/devdevdev-client/pull/170/commits/d8485a5ba93b3d6055c63b612651ec9b9829099b)
- [x] [기술블로그 댓글 드롭다운 모바일 스타일링](https://github.com/dreamyPatisiel/devdevdev-client/pull/170/commits/662385062e630d68814aec7b3d31f527861473cd)
- [x] [기술블로그 - 아티클 전체보기 버튼 변경 (모바일&pc)](https://github.com/dreamyPatisiel/devdevdev-client/pull/170/commits/a6afbfa0336f801b5149b9b5163850bb24ce206e)
- [x] 댓글작성폼 관련 작업 
- [댓글작성폼 모바일 스타일링](https://github.com/dreamyPatisiel/devdevdev-client/pull/170/commits/7d402b42116bd3479d89c02bedafe73295879215)
- [취소 버튼 생성 & 수정하기 텍스트 변경](https://github.com/dreamyPatisiel/devdevdev-client/pull/170/commits/21c778e07647b91f479eae4f4b0f33b04c4f6548)
- [픽픽픽 모바일의 경우 폼의 하단 컴포넌트들 배치 다르게 설정](https://github.com/dreamyPatisiel/devdevdev-client/pull/170/commits/36c4271b6a6869410953b7bdde1c7709189d219d)
- [max-h값 모바일,pc 분기처리](https://github.com/dreamyPatisiel/devdevdev-client/pull/170/commits/fdc5f778fed70aea3c9005adae367153a0201524)
- [픽픽픽에 취소 버튼 클릭 이벤트 함수 넘겨주기](https://github.com/dreamyPatisiel/devdevdev-client/pull/170/commits/528c94d4fa47476ca28568a23a7c074952388c74)
- [WritableComment의 취소함수 props 옵셔널 처리](https://github.com/dreamyPatisiel/devdevdev-client/pull/170/commits/b145a57682fe9db3422049553b59105ead00eb2e)

## 💬 리뷰 요구사항(선택)

- `WritableComment`에서 수정하기 폼이 활성화 될 때 `buttonContainer`스타일이 isMobile값을 제대로 잡지 못해서 웹버전의 스타일링을 적용하고있어요 ,,, ㅜㅜ 이것도 결국 저희가 계속 말하던 SSR의 고질적인 문제인것 같은데 어떻게 해결하면 좋을까요 ? 
- `[DP- 389]` 코드를 이용해서 처리하는 방법도 있을것 같아요 요것도 누락되었는데 확인 다시부탁드려요!
