### PR TITLE
[DP-421] 픽픽픽 댓글 부모댓글 갯수가 3개이상일 때만 베스트댓글 보여지도록 수정

### DIFF
--- a/pages/pickpickpick/[id]/apiHooks/comment/useGetBestComments.tsx
+++ b/pages/pickpickpick/[id]/apiHooks/comment/useGetBestComments.tsx
@@ -9,6 +9,12 @@ interface GetBestCommentsProps {
   size: number;
 }
 
+interface UseGetBestCommentsProps {
+  pickId: string;
+  size: number;
+  parentCommentTotal: number;
+}
+
 const getBestComments = async ({ pickId, size }: GetBestCommentsProps) => {
   const res = await axios.get(`${GET_PICK_DATA}/${pickId}/comments/best?size=${size}`);
 
@@ -18,10 +24,11 @@ const getBestComments = async ({ pickId, size }: GetBestCommentsProps) => {
 export const useGetBestComments = ({
   pickId,
   size,
-}: GetBestCommentsProps): UseQueryResult<any, Error> => {
+  parentCommentTotal,
+}: UseGetBestCommentsProps): UseQueryResult<any, Error> => {
   return useQuery({
     queryKey: ['getBestComments', pickId],
     queryFn: () => getBestComments({ pickId, size }),
-    enabled: !!pickId,
+    enabled: !!pickId && parentCommentTotal > 3,
   });
 };

--- a/pages/pickpickpick/[id]/components/PickCommentSection.tsx
+++ b/pages/pickpickpick/[id]/components/PickCommentSection.tsx
@@ -93,21 +93,13 @@ export default function PickCommentSection({ pickId }: { pickId: string }) {
     );
   };
 
-  const getStatusComponent = (
+  const getStatusCommentComponent = (
     bestCommentsData: UseQueryResult<any, Error>,
     pickCommentsData: InfiniteData<any, unknown> | undefined,
     status: 'success' | 'error' | 'pending',
   ) => {
     if (!pickId) {
       return <></>;
-    }
-
-    {
-      PICK_COMMENT_TOTAL_COUNT === 0 && (
-        <p className='p1 text-[#94A0B0] text-center my-[14rem]'>
-          작성된 댓글이 없어요! 첫댓글을 작성해주세요
-        </p>
-      );
     }
 
     switch (status) {
@@ -121,6 +113,12 @@ export default function PickCommentSection({ pickId }: { pickId: string }) {
       default:
         return (
           <div>
+            {PICK_COMMENT_TOTAL_COUNT === 0 && (
+              <p className='p1 text-[#94A0B0] text-center my-[14rem]'>
+                작성된 댓글이 없어요! 첫댓글을 작성해주세요
+              </p>
+            )}
+
             {currentPickOptionTypes.length === 0 ? (
               bestCommentsData?.data?.datas.map((bestComment: CommentsProps) => (
                 <BestComments key={bestComment.pickCommentId} {...bestComment} pickId={pickId} />
@@ -188,7 +186,7 @@ export default function PickCommentSection({ pickId }: { pickId: string }) {
           </div>
         </div>
 
-        {getStatusComponent(bestCommentsData, pickCommentsData, status)}
+        {getStatusCommentComponent(bestCommentsData, pickCommentsData, status)}
         <div ref={bottomDiv} />
       </div>
     </>

--- a/pages/pickpickpick/[id]/components/PickCommentSection.tsx
+++ b/pages/pickpickpick/[id]/components/PickCommentSection.tsx
@@ -32,8 +32,6 @@ export default function PickCommentSection({ pickId }: { pickId: string }) {
   const { sortOption } = useDropdownStore();
   const isMobile = useIsMobile();
 
-  const { data: bestCommentsData } = useGetBestComments({ pickId, size: 3 });
-
   const { pickCommentsData, isFetchingNextPage, hasNextPage, status, onIntersect } =
     useInfinitePickComments({
       pickId: pickId,
@@ -46,6 +44,12 @@ export default function PickCommentSection({ pickId }: { pickId: string }) {
       pickCommentSort: sortOption as PickCommentDropdownProps,
     });
   const PICK_COMMENT_TOTAL_COUNT = pickCommentsData?.pages[0].data.totalElements;
+
+  const { data: bestCommentsData } = useGetBestComments({
+    pickId,
+    size: 3,
+    parentCommentTotal: pickCommentsData?.pages[0].data.totalOriginParentComments,
+  });
 
   useObserver({
     target: bottomDiv,
@@ -117,10 +121,13 @@ export default function PickCommentSection({ pickId }: { pickId: string }) {
       default:
         return (
           <div>
-            {currentPickOptionTypes.length === 0 &&
+            {currentPickOptionTypes.length === 0 ? (
               bestCommentsData?.data?.datas.map((bestComment: CommentsProps) => (
                 <BestComments key={bestComment.pickCommentId} {...bestComment} pickId={pickId} />
-              ))}
+              ))
+            ) : (
+              <></>
+            )}
 
             {pickCommentsData?.pages.map((group, index) => (
               <Fragment key={index}>


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
- [x] [feat: 픽픽픽 댓글 부모댓글 갯수가 3개이상일 때만 베스트댓글 보여지도록 수정](https://github.com/dreamyPatisiel/devdevdev-client/commit/0c5f8445cc78240e877cb880ac8e6eca59e49185)

## 🔗 참고할만한 자료(선택)
> 슬랙이나 피그마, Jira 등 참고 링크를 첨부해주세요
- [슬랙 링크](https://dreamy-patisiel.slack.com/archives/C076TT1ASNB/p1731221271199979?thread_ts=1730961402.999999&cid=C076TT1ASNB)

