### PR TITLE
[DP-425] fix: 베스트댓글 뱃지 스타일 수정

### DIFF
--- a/components/common/comment/BestCommentTag.tsx
+++ b/components/common/comment/BestCommentTag.tsx
@@ -1,6 +1,6 @@
 export default function BestCommentTag() {
   return (
-    <span className='text-[#40FF81] border border-[#40FF81] c1 font-bold px-[0.98rem] py-[0.3rem] rounded-[10rem] mr-[1.6rem]'>
+    <span className='bg-[#40FF81] border border-[#40FF81] text-black c1 font-bold px-[0.98rem] py-[0.3rem] rounded-[10rem] mr-[1.6rem]'>
       Best
     </span>
   );


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
- [x] 베스트댓글 뱃지 스타일 수정사항 반영

<img width="807" alt="image" src="https://github.com/user-attachments/assets/98d621e5-8170-47ec-98cf-15c005d2fd56">


## 🔗 참고할만한 자료(선택)
> 슬랙이나 피그마, Jira 등 참고 링크를 첨부해주세요
- [피그마](https://www.figma.com/design/hCJ1zuRGfwMws8NgjFU9fn/%E2%9D%A4%EF%B8%8F%E2%80%8D%F0%9F%A9%B9-2%EC%B0%A8-%EA%B0%9C%EC%84%A0-%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8?node-id=2177-1724&t=5OIoC5Isu96vMDLB-4)
