### PR TITLE
[DP-438] 드롭다운 상태 분리 - 픽픽픽, 기술블로그

### DIFF
--- a/components/common/dropdowns/dropdown.tsx
+++ b/components/common/dropdowns/dropdown.tsx
@@ -21,6 +21,7 @@ import {
   DropdownOptionProps,
   useBlameReasonStore,
   useDropdownStore,
+  usePickDropdownStore,
   useSelectedStore,
 } from '@/stores/dropdownStore';
 
@@ -38,12 +39,15 @@ export function Dropdown({
   };
 
   const { sortOption, setSort } = useDropdownStore();
+  const { sortOption: pickSortOption, setSort: setPickSort } = usePickDropdownStore();
 
   let dropdownOptions: string[] = [];
+  let selectedSortOption = sortOption;
 
   switch (type) {
     case 'pickpickpick':
       dropdownOptions = pickpickpickDropdownOptions;
+      selectedSortOption = pickSortOption;
       break;
     case 'techblog':
       dropdownOptions = techBlogDropdownOptions;
@@ -64,10 +68,17 @@ export function Dropdown({
   const DISABLE_CLASS = 'pointer-events-none opacity-50';
 
   useEffect(() => {
-    if (!dropdownOptions.includes(sortOption)) setSort(dropdownOptions[0] as DropdownOptionProps);
+    if (!dropdownOptions.includes(selectedSortOption))
+      setSort(dropdownOptions[0] as DropdownOptionProps);
   }, []);
 
   const handleOptionSelected = (value: DropdownOptionProps) => () => {
+    if (type === 'pickpickpick') {
+      setPickSort(value);
+      setDropdownOpen(false);
+      return;
+    }
+
     setSort(value);
     setDropdownOpen(false);
   };
@@ -84,7 +95,7 @@ export function Dropdown({
         htmlFor='dropdown'
         className='text-gray5 text-c1 leading-[2.4rem] cursor-pointer flex justify-between items-center px-[1.2rem] py-[0.8rem] '
       >
-        {dropdownOptionToKorean(sortOption)}
+        {dropdownOptionToKorean(selectedSortOption)}
         <Image src={AngleDown} alt='아래방향 화살표' />
       </label>
 
@@ -97,7 +108,7 @@ export function Dropdown({
             <li
               key={index}
               onClick={handleOptionSelected(option as DropdownOptionProps)}
-              className={`cursor-pointer hover:text-gray5 ${sortOption === option && 'text-gray5'}`}
+              className={`cursor-pointer hover:text-gray5 ${selectedSortOption === option && 'text-gray5'}`}
             >
               {dropdownOptionToKorean(option as DropdownOptionProps)}
             </li>

--- a/components/common/dropdowns/dropdown.tsx
+++ b/components/common/dropdowns/dropdown.tsx
@@ -23,6 +23,7 @@ import {
   useDropdownStore,
   usePickDropdownStore,
   useSelectedStore,
+  useTechblogDropdownStore,
 } from '@/stores/dropdownStore';
 
 export function Dropdown({
@@ -40,6 +41,7 @@ export function Dropdown({
 
   const { sortOption, setSort } = useDropdownStore();
   const { sortOption: pickSortOption, setSort: setPickSort } = usePickDropdownStore();
+  const { sortOption: techblogSortOption, setSort: setTechblogSort } = useTechblogDropdownStore();
 
   let dropdownOptions: string[] = [];
   let selectedSortOption = sortOption;
@@ -51,6 +53,7 @@ export function Dropdown({
       break;
     case 'techblog':
       dropdownOptions = techBlogDropdownOptions;
+      selectedSortOption = techblogSortOption;
       break;
     case 'bookmark':
       dropdownOptions = bookmarkDropdownOptions;
@@ -73,14 +76,17 @@ export function Dropdown({
   }, []);
 
   const handleOptionSelected = (value: DropdownOptionProps) => () => {
+    setDropdownOpen(false);
+
     if (type === 'pickpickpick') {
-      setPickSort(value);
-      setDropdownOpen(false);
-      return;
+      return setPickSort(value);
+    }
+
+    if (type === 'techblog') {
+      return setTechblogSort(value);
     }
 
     setSort(value);
-    setDropdownOpen(false);
   };
 
   return (

--- a/components/common/dropdowns/dropdown.tsx
+++ b/components/common/dropdowns/dropdown.tsx
@@ -71,8 +71,9 @@ export function Dropdown({
   const DISABLE_CLASS = 'pointer-events-none opacity-50';
 
   useEffect(() => {
-    if (!dropdownOptions.includes(selectedSortOption))
+    if (!dropdownOptions.includes(sortOption)) {
       setSort(dropdownOptions[0] as DropdownOptionProps);
+    }
   }, []);
 
   const handleOptionSelected = (value: DropdownOptionProps) => () => {

--- a/components/common/dropdowns/mobileDropdown.tsx
+++ b/components/common/dropdowns/mobileDropdown.tsx
@@ -5,7 +5,12 @@ import Image from 'next/image';
 import { dropdownOptionToKorean } from '@utils/dropdownOptionToKorean';
 import { cn } from '@utils/mergeStyle';
 
-import { DropdownOptionProps, useDropdownStore } from '@stores/dropdownStore';
+import {
+  DropdownOptionProps,
+  useDropdownStore,
+  usePickDropdownStore,
+  useTechblogDropdownStore,
+} from '@stores/dropdownStore';
 
 import AngleDown from '@public/image/dropdown-angle-down.svg';
 
@@ -27,15 +32,20 @@ export default function MobileDropdown({
   const [showBottom, setShowBottom] = useState(false);
 
   const { sortOption, setSort } = useDropdownStore();
+  const { sortOption: pickSortOption, setSort: setPickSort } = usePickDropdownStore();
+  const { sortOption: techblogSortOption, setSort: setTechblogSort } = useTechblogDropdownStore();
 
   let dropdownOptions: string[] = [];
+  let selectedSortOption = sortOption;
 
   switch (type) {
     case 'pickpickpick':
       dropdownOptions = pickpickpickDropdownOptions;
+      selectedSortOption = pickSortOption;
       break;
     case 'techblog':
       dropdownOptions = techBlogDropdownOptions;
+      selectedSortOption = techblogSortOption;
       break;
     case 'bookmark':
       dropdownOptions = bookmarkDropdownOptions;
@@ -49,8 +59,17 @@ export default function MobileDropdown({
   }
 
   const handleOptionSelected = (value: DropdownOptionProps) => () => {
-    setSort(value);
     setShowBottom(false);
+
+    if (type === 'pickpickpick') {
+      return setPickSort(value);
+    }
+
+    if (type === 'techblog') {
+      return setTechblogSort(value);
+    }
+
+    setSort(value);
   };
 
   const baseStyle = 'px-[2.4rem] py-[1.2rem] st2 text-gray4 cursor-pointer';
@@ -63,7 +82,7 @@ export default function MobileDropdown({
         className='rounded-[10rem] px-[1.4rem] py-[0.8rem] bg-gray1 text-gray4 flex gap-[0.8rem] c1 font-bold cursor-pointer'
         onClick={() => setShowBottom(true)}
       >
-        {dropdownOptionToKorean(sortOption)}
+        {dropdownOptionToKorean(selectedSortOption)}
         <Image src={AngleDown} alt='아래방향 화살표' />
       </div>
 
@@ -75,7 +94,10 @@ export default function MobileDropdown({
               <li
                 key={index}
                 onClick={handleOptionSelected(option as DropdownOptionProps)}
-                className={cn(baseStyle, sortOption === option ? activeStyle : nonActiveStyle)}
+                className={cn(
+                  baseStyle,
+                  selectedSortOption === option ? activeStyle : nonActiveStyle,
+                )}
               >
                 {dropdownOptionToKorean(option as DropdownOptionProps)}
               </li>

--- a/components/common/header/header.tsx
+++ b/components/common/header/header.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 
 import { useQueryClient } from '@tanstack/react-query';
 
-import { useDropdownStore } from '@stores/dropdownStore';
+import { usePickDropdownStore, useTechblogDropdownStore } from '@stores/dropdownStore';
 import { useLoginStatusStore } from '@stores/loginStore';
 import { useLoginModalStore } from '@stores/modalStore';
 import { useCompanyIdStore, useSearchKeywordStore } from '@stores/techBlogStore';
@@ -26,6 +26,8 @@ export default function Header() {
   const { loginStatus, setLoginStatus, setLogoutStatus } = useLoginStatusStore();
   const { setSearchKeyword } = useSearchKeywordStore();
   const { setCompanyId } = useCompanyIdStore();
+  const { setSort: setPickSort } = usePickDropdownStore();
+  const { setSort: setTechblogSort } = useTechblogDropdownStore();
 
   useEffect(() => {
     if (userInfo?.accessToken) {
@@ -39,12 +41,14 @@ export default function Header() {
 
   const invalidPickQuery = () => {
     queryClient.invalidateQueries({ queryKey: ['pickData'] });
+    setPickSort('POPULAR');
   };
 
   const refreshTechArticleParams = () => {
     setSearchKeyword('');
     setCompanyId(undefined);
     queryClient.invalidateQueries({ queryKey: ['techBlogData'] });
+    setTechblogSort('LATEST');
   };
 
   return (

--- a/components/common/header/header.tsx
+++ b/components/common/header/header.tsx
@@ -44,6 +44,7 @@ export default function Header() {
   const refreshTechArticleParams = () => {
     setSearchKeyword('');
     setCompanyId(undefined);
+    queryClient.invalidateQueries({ queryKey: ['techBlogData'] });
   };
 
   return (

--- a/components/common/header/header.tsx
+++ b/components/common/header/header.tsx
@@ -42,6 +42,11 @@ export default function Header() {
     queryClient.invalidateQueries({ queryKey: ['pickData'] });
   };
 
+  const refreshPickParams = () => {
+    queryClient.invalidateQueries({ queryKey: ['pickData'] });
+    setSort('POPULAR');
+  };
+
   const refreshTechArticleParams = () => {
     setSearchKeyword('');
     setCompanyId(undefined);
@@ -62,10 +67,7 @@ export default function Header() {
 
         <ul className='text-white flex flex-row items-center gap-[4.8rem] font-bold'>
           <li>
-            <Link
-              href={PICKPICKPICK.MAIN}
-              onClick={() => queryClient.invalidateQueries({ queryKey: ['pickData'] })}
-            >
+            <Link href={PICKPICKPICK.MAIN} onClick={refreshPickParams}>
               픽픽픽 💘
             </Link>
           </li>

--- a/components/common/header/header.tsx
+++ b/components/common/header/header.tsx
@@ -26,7 +26,6 @@ export default function Header() {
   const { loginStatus, setLoginStatus, setLogoutStatus } = useLoginStatusStore();
   const { setSearchKeyword } = useSearchKeywordStore();
   const { setCompanyId } = useCompanyIdStore();
-  const { setSort } = useDropdownStore();
 
   useEffect(() => {
     if (userInfo?.accessToken) {
@@ -38,19 +37,13 @@ export default function Header() {
     queryClient.invalidateQueries({ queryKey: ['pickData'] });
   }, [userInfo, queryClient, setLoginStatus, setLogoutStatus]);
 
-  const handleClickLogo = () => {
+  const invalidPickQuery = () => {
     queryClient.invalidateQueries({ queryKey: ['pickData'] });
-  };
-
-  const refreshPickParams = () => {
-    queryClient.invalidateQueries({ queryKey: ['pickData'] });
-    setSort('POPULAR');
   };
 
   const refreshTechArticleParams = () => {
     setSearchKeyword('');
     setCompanyId(undefined);
-    setSort('LATEST');
   };
 
   return (
@@ -61,13 +54,13 @@ export default function Header() {
           borderBottom: '1px solid #DEE5ED',
         }}
       >
-        <Link href={MAIN} aria-label='메인' onClick={handleClickLogo}>
+        <Link href={MAIN} aria-label='메인' onClick={invalidPickQuery}>
           <Image src={DevLogo} priority alt='DEVDEVDEV 로고' className='cursor-pointer' />
         </Link>
 
         <ul className='text-white flex flex-row items-center gap-[4.8rem] font-bold'>
           <li>
-            <Link href={PICKPICKPICK.MAIN} onClick={refreshPickParams}>
+            <Link href={PICKPICKPICK.MAIN} onClick={invalidPickQuery}>
               픽픽픽 💘
             </Link>
           </li>

--- a/components/common/header/mobileHeader.tsx
+++ b/components/common/header/mobileHeader.tsx
@@ -6,7 +6,11 @@ import { useRouter } from 'next/router';
 
 import { useQueryClient } from '@tanstack/react-query';
 
-import { useDropdownStore } from '@stores/dropdownStore';
+import {
+  useDropdownStore,
+  usePickDropdownStore,
+  useTechblogDropdownStore,
+} from '@stores/dropdownStore';
 import { useLoginStatusStore } from '@stores/loginStore';
 import { useLoginModalStore } from '@stores/modalStore';
 import { useCompanyIdStore, useSearchKeywordStore } from '@stores/techBlogStore';
@@ -28,18 +32,21 @@ export default function MobileHeader() {
   const { loginStatus } = useLoginStatusStore();
   const { setSearchKeyword } = useSearchKeywordStore();
   const { setCompanyId } = useCompanyIdStore();
-  const { setSort } = useDropdownStore();
   const { openLoginModal } = useLoginModalStore();
   const { userInfo } = useUserInfoStore();
+  const { setSort: setPickSort } = usePickDropdownStore();
+  const { setSort: setTechblogSort } = useTechblogDropdownStore();
 
-  const handleClickLogo = () => {
+  const invalidPickQuery = () => {
     queryClient.invalidateQueries({ queryKey: ['pickData'] });
+    setPickSort('POPULAR');
   };
 
   const refreshTechArticleParams = () => {
     setSearchKeyword('');
     setCompanyId(undefined);
-    setSort('LATEST');
+    queryClient.invalidateQueries({ queryKey: ['techBlogData'] });
+    setTechblogSort('LATEST');
   };
 
   const loginStatusButton = (loginStatus: 'login' | 'logout' | 'loading' | 'account-delete') => {
@@ -68,7 +75,7 @@ export default function MobileHeader() {
     <header className='h-[9rem]'>
       <div className='flex flex-col bg-gray1 border-b border-b-gray5 fixed w-full z-40'>
         <div className='flex justify-between px-[1.6rem] py-[1.2rem]'>
-          <Link href={MAIN} aria-label='메인' onClick={handleClickLogo}>
+          <Link href={MAIN} aria-label='메인' onClick={invalidPickQuery}>
             <Image src={DevLogo} alt='DEVDEVDEV 로고' width={64} height={23} />
           </Link>
           {/* <Image src={HeaderBar} alt='바 로고' /> */}
@@ -79,10 +86,7 @@ export default function MobileHeader() {
         <nav className='px-[1.6rem] py-[0.9rem] p2 font-bold'>
           <ul className='flex gap-[4.8rem]'>
             <li>
-              <Link
-                href={PICKPICKPICK.MAIN}
-                onClick={() => queryClient.invalidateQueries({ queryKey: ['pickData'] })}
-              >
+              <Link href={PICKPICKPICK.MAIN} onClick={invalidPickQuery}>
                 픽픽픽 💘
               </Link>
             </li>

--- a/constants/DropdownOptionArr.ts
+++ b/constants/DropdownOptionArr.ts
@@ -1,6 +1,6 @@
 export const pickpickpickDropdownOptions = [
-  'LATEST',
   'POPULAR',
+  'LATEST',
   'MOST_VIEWED' /*'MOST_COMMENTED'*/,
 ];
 export const bookmarkDropdownOptions = ['BOOKMARKED', 'LATEST' /*'MOST_COMMENTED'*/];

--- a/pages/pickpickpick/index.page.tsx
+++ b/pages/pickpickpick/index.page.tsx
@@ -24,7 +24,7 @@ import IconPencil from '@public/image/pencil-alt.svg';
 
 import { META } from '@/constants/metaData';
 import { ROUTES } from '@/constants/routes';
-import { PickDropdownProps, useDropdownStore } from '@/stores/dropdownStore';
+import { PickDropdownProps, usePickDropdownStore } from '@/stores/dropdownStore';
 
 import { MobilePickInfo, PickInfo } from './components/PickInfo';
 import { PickDataProps } from './types/pick';
@@ -32,13 +32,14 @@ import { PickDataProps } from './types/pick';
 const DynamicComponent = dynamic(() => import('@/pages/pickpickpick/components/PickContainer'));
 
 export default function Index() {
-  const { loginStatus } = useLoginStatusStore();
-  const { openLoginModal, isLoginModalOpen, setDescription } = useLoginModalStore();
   const bottom = useRef(null);
 
   const { MAIN, POSTING } = ROUTES.PICKPICKPICK;
 
-  const { sortOption } = useDropdownStore();
+  const { loginStatus } = useLoginStatusStore();
+  const { openLoginModal, isLoginModalOpen, setDescription } = useLoginModalStore();
+  const { sortOption } = usePickDropdownStore();
+
   const isMobile = useIsMobile();
 
   const { title, description, keyword, url } = META.PICK;

--- a/pages/techblog/index.page.tsx
+++ b/pages/techblog/index.page.tsx
@@ -4,7 +4,7 @@ import dynamic from 'next/dynamic';
 
 import { InfiniteData, useQueryClient } from '@tanstack/react-query';
 
-import { TechBlogDropdownProps, useDropdownStore } from '@stores/dropdownStore';
+import { TechBlogDropdownProps, useTechblogDropdownStore } from '@stores/dropdownStore';
 import { useCompanyIdStore, useSearchKeywordStore } from '@stores/techBlogStore';
 import { useToastVisibleStore } from '@stores/toastVisibleStore';
 
@@ -33,7 +33,7 @@ export default function Index() {
   const queryClient = useQueryClient();
   const isMobile = useIsMobile();
 
-  const { sortOption, setSort } = useDropdownStore();
+  const { sortOption, setSort } = useTechblogDropdownStore();
   const { searchKeyword, setSearchKeyword } = useSearchKeywordStore();
   const { companyId, setCompanyId } = useCompanyIdStore();
   const { setToastInvisible } = useToastVisibleStore();

--- a/stores/dropdownStore.ts
+++ b/stores/dropdownStore.ts
@@ -33,6 +33,14 @@ export const useDropdownStore = create<DropDownStoreProps>((set) => ({
   setSort: (sortOption: DropdownOptionProps) => set({ sortOption: sortOption }),
 }));
 
+const createDropdownStore = (defaultSortOption: DropdownOptionProps) =>
+  create<DropDownStoreProps>((set) => ({
+    sortOption: defaultSortOption,
+    setSort: (sortOption: DropdownOptionProps) => set({ sortOption }),
+  }));
+
+export const usePickDropdownStore = createDropdownStore('POPULAR');
+
 // 신고하기 드롭다운 데이터 저장 store
 interface SelectedStoreProps {
   selectedBlameData: TypeBlames | null;

--- a/stores/dropdownStore.ts
+++ b/stores/dropdownStore.ts
@@ -40,6 +40,7 @@ const createDropdownStore = (defaultSortOption: DropdownOptionProps) =>
   }));
 
 export const usePickDropdownStore = createDropdownStore('POPULAR');
+export const useTechblogDropdownStore = createDropdownStore('LATEST');
 
 // 신고하기 드롭다운 데이터 저장 store
 interface SelectedStoreProps {

--- a/stores/dropdownStore.ts
+++ b/stores/dropdownStore.ts
@@ -5,7 +5,7 @@ import { TechBlogCommentsDropdownProps } from '@pages/techblog/types/techComment
 
 import { TypeBlames } from '@/api/useGetBlames';
 
-export type PickDropdownProps = 'LATEST' | 'POPULAR' | 'MOST_VIEWED' | 'MOST_COMMENTED';
+export type PickDropdownProps = 'POPULAR' | 'LATEST' | 'MOST_VIEWED' | 'MOST_COMMENTED';
 
 export type PickCommentDropdownProps = 'LATEST' | 'MOST_LIKED' | 'MOST_COMMENTED';
 
@@ -24,12 +24,12 @@ export type DropdownOptionProps =
   | PickCommentDropdownProps;
 
 interface DropDownStoreProps {
-  sortOption: DropdownOptionProps;
+  sortOption: DropdownOptionProps | '';
   setSort: (sortOption: DropdownOptionProps) => void;
 }
 
 export const useDropdownStore = create<DropDownStoreProps>((set) => ({
-  sortOption: 'LATEST',
+  sortOption: '',
   setSort: (sortOption: DropdownOptionProps) => set({ sortOption: sortOption }),
 }));
 

--- a/utils/dropdownOptionToKorean.ts
+++ b/utils/dropdownOptionToKorean.ts
@@ -1,6 +1,6 @@
 import { DropdownOptionProps } from '@stores/dropdownStore';
 
-export const dropdownOptionToKorean = (englishOption: DropdownOptionProps) => {
+export const dropdownOptionToKorean = (englishOption: DropdownOptionProps | '') => {
   switch (englishOption) {
     case 'LATEST':
       return '최신순';


### PR DESCRIPTION
## 📝 작업 내용
- [x] 픽픽픽 디폴트 인기순으로 수정 [fix: 픽픽픽 메인 sorting 기본값 인기순으로 수정](https://github.com/dreamyPatisiel/devdevdev-client/commit/4ecf836857918bf1f5870f91494f63fb8385d425)
- [x] 드롭다운 상태 분리 - 픽픽픽 [feat: createDropdownStore 생성 - usePickDropdownStore 적용](https://github.com/dreamyPatisiel/devdevdev-client/commit/762e89693a10489d59fda609d6e8b0fc3ccabde4)
- [x] 드롭다운 상태 분리 - 기술블로그 [feat: techblog - useTechblogDropdownStore 적용](https://github.com/dreamyPatisiel/devdevdev-client/commit/c3a54bce7119c45c94eb41a2805b334e0c62ac0f)
- [x] 픽픽픽, 기술블로그 상태 분리로 인해 헤더 메뉴 클릭 시 sorting은 해제했어요! [fix: 픽픽픽, 드롭다운 상태 분리로 인한 헤더 메뉴 클릭 시 sorting 원복](https://github.com/dreamyPatisiel/devdevdev-client/pull/189/commits/acb2e2e3774e1dcd3c57c090cf09fa74a6110f03)

