### PR TITLE
[DP-441] 픽픽픽 이슈 수정

### DIFF
--- a/pages/pickpickpick/[id]/apiHooks/comment/useInfinitePickComments.tsx
+++ b/pages/pickpickpick/[id]/apiHooks/comment/useInfinitePickComments.tsx
@@ -6,12 +6,11 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { GET_PICK_DATA } from '@pages/pickpickpick/constants/pickApi';
 import { PICK_COMMENT_VIEW_SIZE } from '@pages/pickpickpick/constants/pickConstants';
+import { PickOptionType } from '@pages/pickpickpick/types/pick';
 
 import { PickCommentDropdownProps } from '@stores/dropdownStore';
 
 import { pickCommentOptions } from '@/constants/DropdownOptionArr';
-
-import { PickOptionType } from '../../components/Comments';
 
 interface GetPickCommentsProp {
   pickId: string;

--- a/pages/pickpickpick/[id]/apiHooks/comment/useInfinitePickComments.tsx
+++ b/pages/pickpickpick/[id]/apiHooks/comment/useInfinitePickComments.tsx
@@ -9,6 +9,8 @@ import { PICK_COMMENT_VIEW_SIZE } from '@pages/pickpickpick/constants/pickConsta
 
 import { PickCommentDropdownProps } from '@stores/dropdownStore';
 
+import { pickCommentOptions } from '@/constants/DropdownOptionArr';
+
 import { PickOptionType } from '../../components/Comments';
 
 interface GetPickCommentsProp {
@@ -71,6 +73,8 @@ export const useInfinitePickComments = ({
   currentPickOptionTypes,
   size,
 }: GetPickCommentsProp) => {
+  const isValidSortOption = pickCommentOptions.includes(pickCommentSort);
+
   const {
     data: pickCommentsData,
     fetchNextPage,
@@ -98,7 +102,7 @@ export const useInfinitePickComments = ({
       const lastPickId = lastPage?.data.content[PICK_COMMENT_VIEW_SIZE - 1]?.pickCommentId;
       return lastPickId ?? undefined;
     },
-    enabled: !!pickId,
+    enabled: !!pickId && isValidSortOption,
   });
 
   const onIntersect = useCallback(

--- a/pages/pickpickpick/[id]/components/Comment.tsx
+++ b/pages/pickpickpick/[id]/components/Comment.tsx
@@ -220,7 +220,7 @@ export default function Comment({
   return (
     <div
       className={`flex flex-col gap-[2.4rem] pt-[2.4rem] pb-[3.2rem]
-        ${isMobile ? 'px-[1.6rem]' : 'px-[3.2rem]'}     
+        ${isSubComment && (isMobile ? 'px-[1.6rem]' : 'px-[3.2rem]')}     
         ${commentContainerStyle()}`}
     >
       <CommentHeader

--- a/pages/pickpickpick/[id]/components/Comments.tsx
+++ b/pages/pickpickpick/[id]/components/Comments.tsx
@@ -20,7 +20,7 @@ import { useInfinitePickComments } from '../apiHooks/comment/useInfinitePickComm
 import BestComments from './BestComments';
 import CommentSet, { CommentsProps } from './CommentSet';
 
-type PickOptionType = 'firstPickOption' | 'secondPickOption' | '';
+export type PickOptionType = 'firstPickOption' | 'secondPickOption' | '';
 
 export default function Comments({ pickId }: { pickId: string }) {
   const [currentPickOptionTypes, setCurrentPickOptionTypes] = useState<PickOptionType[]>([]);
@@ -32,13 +32,8 @@ export default function Comments({ pickId }: { pickId: string }) {
 
   const { pickCommentsData, isFetchingNextPage, hasNextPage, status, onIntersect } =
     useInfinitePickComments({
-      pickId: pickId,
-      pickOptionTypes:
-        currentPickOptionTypes.length === 0
-          ? ''
-          : currentPickOptionTypes.length === 1
-            ? currentPickOptionTypes[0]
-            : `${currentPickOptionTypes[0]}&pickOptionTypes=${currentPickOptionTypes[1]}`,
+      pickId,
+      currentPickOptionTypes,
       pickCommentSort: sortOption as PickCommentDropdownProps,
     });
   const PICK_COMMENT_TOTAL_COUNT = pickCommentsData?.pages[0].data.totalElements;

--- a/pages/pickpickpick/[id]/components/Comments.tsx
+++ b/pages/pickpickpick/[id]/components/Comments.tsx
@@ -2,6 +2,8 @@ import { Fragment, useRef, useState } from 'react';
 
 import { InfiniteData, UseQueryResult } from '@tanstack/react-query';
 
+import { PickOptionType } from '@pages/pickpickpick/types/pick';
+
 import { PickCommentDropdownProps, useDropdownStore } from '@stores/dropdownStore';
 
 import useIsMobile from '@hooks/useIsMobile';
@@ -19,8 +21,6 @@ import { useGetBestComments } from '../apiHooks/comment/useGetBestComments';
 import { useInfinitePickComments } from '../apiHooks/comment/useInfinitePickComments';
 import BestComments from './BestComments';
 import CommentSet, { CommentsProps } from './CommentSet';
-
-export type PickOptionType = 'firstPickOption' | 'secondPickOption' | '';
 
 export default function Comments({ pickId }: { pickId: string }) {
   const [currentPickOptionTypes, setCurrentPickOptionTypes] = useState<PickOptionType[]>([]);

--- a/pages/pickpickpick/[id]/index.page.tsx
+++ b/pages/pickpickpick/[id]/index.page.tsx
@@ -119,12 +119,14 @@ export default function Index() {
           </div>
 
           {pickDetailData?.isAuthor && (
-            <MoreButton
-              moreButtonList={PICK_DETAIL_MORE_BUTTON_TYPE.map((type) => ({
-                buttonType: type,
-                moreButtonOnclick: handleModalButton(type),
-              }))}
-            />
+            <div className='flex-shrink-0 ml-[2.1rem]'>
+              <MoreButton
+                moreButtonList={PICK_DETAIL_MORE_BUTTON_TYPE.map((type) => ({
+                  buttonType: type,
+                  moreButtonOnclick: handleModalButton(type),
+                }))}
+              />
+            </div>
           )}
         </div>
 

--- a/pages/pickpickpick/types/pick.ts
+++ b/pages/pickpickpick/types/pick.ts
@@ -29,3 +29,5 @@ export interface GetPickDataProps {
   pickSort: 'LATEST' | 'POPULAR' | 'MOST_VIEWED' | 'MOST_COMMENTED';
   size?: number;
 }
+
+export type PickOptionType = 'firstPickOption' | 'secondPickOption' | '';


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
- [x] 픽픽픽 상세페이지 탕후루버튼 shrink 적용하여 줄어들지 않도록 수정했어요! [fix: 픽픽픽 글 더보기 버튼 이미지 줄어드는 이슈 수정](https://github.com/dreamyPatisiel/devdevdev-client/pull/191/commits/ec6cf82406db1310114394bfbc703a1d26ed4fe2)
- [x] 픽픽픽 댓글 api 호출 시 sortoption이 valid할 때 호출하도록 수정했어요! [fix: 픽픽픽 댓글 api sortoption이 valid할 때 호출되도록 수정](https://github.com/dreamyPatisiel/devdevdev-client/pull/191/commits/6617e5fe1e7d36ab8c929fd2ae05968e03d1dc1f)
- [x] 픽픽픽 댓글의 pickoption 쿼리 파라미터를 넘길 때 배열로 넘어가는 경우가 있어서 그 부분을 serailze 로직을 추가하여 리팩토링 했어요! [refactor: 쿼리파라미터 배열일 때 serializer 로직 적용](https://github.com/dreamyPatisiel/devdevdev-client/pull/191/commits/091e491a0ccf3faa4c45cc09fdfb932bc59e22f1)
- [x] [fix: 픽픽픽 subComment 일 때만 padding 설정](https://github.com/dreamyPatisiel/devdevdev-client/pull/191/commits/173526451215031baac036a079e518148915422b)

## 🔗 참고할만한 자료(선택)
> 슬랙이나 피그마, Jira 등 참고 링크를 첨부해주세요
- [탕후루 이슈 스레드](https://dreamy-patisiel.slack.com/archives/C076TT1ASNB/p1732956176400929)
- [댓글 api 호출 이슈 스레드](https://dreamy-patisiel.slack.com/archives/C076TT1ASNB/p1733064624746929)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
