### PR TITLE
[DP-443] hotfix: 픽픽픽 상세페이지 투표 글 그라데이션 수정

### DIFF
--- a/pages/pickpickpick/[id]/components/VoteCard.tsx
+++ b/pages/pickpickpick/[id]/components/VoteCard.tsx
@@ -4,8 +4,6 @@ import Image from 'next/image';
 
 import useIsMobile from '@hooks/useIsMobile';
 
-import { EllipsisGradientText } from '@components/common/EllipsisGradientText';
-
 import AngleDownPoint from '@public/image/pickpickpick/angle-down-point.svg';
 import AngleUpPoint from '@public/image/pickpickpick/angle-up-point.svg';
 
@@ -41,28 +39,32 @@ export default function VoteCard({
         {(pickDetailOptionData?.content ||
           pickDetailOptionData?.pickDetailOptionImages.length !== 0) && (
           <div className='border-t-[0.1rem] border-t-gray1 pt-[2.4rem] flex flex-col gap-[2.4rem]'>
-            <EllipsisGradientText
-              isFullContents={isFullContents}
-              startPercent={isFullContents ? '100%' : '0%'}
-              endPercent='100%'
-              className={`p1 min-h-[8.9rem] ${!isFullContents && 'ellipsis '}`}
+            <div
+              className={`${
+                isFullContents
+                  ? ''
+                  : `bg-gradient-to-t from-black to-transparent overflow-hidden
+                ${isMobile ? 'max-h-[34.4rem]' : 'max-h-[8.9rem]'}`
+              }`}
             >
-              <MarkdownViewer pickDetailOptionContents={pickDetailOptionData?.content} />
+              <div className='relative -z-[1]'>
+                <MarkdownViewer pickDetailOptionContents={pickDetailOptionData?.content} />
 
-              {pickDetailOptionData?.pickDetailOptionImages.length !== 0 && (
-                <p className='p2 font-light text-gray5 py-[2.4rem]'>첨부 이미지</p>
-              )}
-              <div className='flex flex-col gap-[2.4rem]'>
-                {pickDetailOptionData?.pickDetailOptionImages?.map((optionImage) => (
-                  <img
-                    src={optionImage.imageUrl}
-                    alt={`픽픽픽 옵션 이미지-${optionImage.id}`}
-                    key={optionImage.id}
-                    className='rounded-[1.2rem]'
-                  />
-                ))}
+                {pickDetailOptionData?.pickDetailOptionImages.length !== 0 && (
+                  <p className='p2 font-light text-gray5 py-[2.4rem]'>첨부 이미지</p>
+                )}
+                <div className='flex flex-col gap-[2.4rem]'>
+                  {pickDetailOptionData?.pickDetailOptionImages?.map((optionImage) => (
+                    <img
+                      src={optionImage.imageUrl}
+                      alt={`픽픽픽 옵션 이미지-${optionImage.id}`}
+                      key={optionImage.id}
+                      className='rounded-[1.2rem]'
+                    />
+                  ))}
+                </div>
               </div>
-            </EllipsisGradientText>
+            </div>
 
             <button
               className={`p2 font-bold text-point1 flex items-center gap-[0.8rem] justify-center`}


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
- [x] 픽픽픽 상세페이지 투표 글의 그라데이션 적용 방법을 수정하여 아래 이슈를 해결했습니다. [fix: 픽픽픽 픽픽픽 상세페이지 투표 글 그라데이션 수정](https://github.com/dreamyPatisiel/devdevdev-client/commit/1eaa3ff068e7de046d60c067b691c603daece058)
- [글자가 겹쳐보이는 현상]
<img src="https://github.com/user-attachments/assets/febcd710-fb41-4c8e-9a27-529ea6541d90" width="300" />
<img src="https://github.com/user-attachments/assets/3d3f3f8b-7b17-42c4-963e-4131b636d0f8" width="300" />

- [마크다운 적용 시 글자가 보이지 않는 현상]
<img width="300" alt="image" src="https://github.com/user-attachments/assets/3544aa18-2285-47bf-8e37-e14bf00f9047">
<img src="https://github.com/user-attachments/assets/78d4d337-18fa-4729-85e4-31393102f53f" width="300" />


## 🔗 참고할만한 자료(선택)
> 슬랙이나 피그마, Jira 등 참고 링크를 첨부해주세요
- [이슈 스레드](https://dreamy-patisiel.slack.com/archives/C07AYDVGADB/p1733244766173509?thread_ts=1733244406.893779&cid=C07AYDVGADB)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
