### PR TITLE
[ DP-435 ] 기술블로그 무한스크롤 첫페이지 서버사이드 렌더링 리팩토링건

### DIFF
--- a/components/common/header/header.tsx
+++ b/components/common/header/header.tsx
@@ -46,7 +46,7 @@ export default function Header() {
 
   const refreshTechArticleParams = () => {
     setSearchKeyword('');
-    setCompanyId(undefined);
+    setCompanyId(null);
     queryClient.invalidateQueries({ queryKey: ['techBlogData'] });
     setTechblogSort('LATEST');
   };

--- a/components/common/header/mobileHeader.tsx
+++ b/components/common/header/mobileHeader.tsx
@@ -44,7 +44,7 @@ export default function MobileHeader() {
 
   const refreshTechArticleParams = () => {
     setSearchKeyword('');
-    setCompanyId(undefined);
+    setCompanyId(null);
     queryClient.invalidateQueries({ queryKey: ['techBlogData'] });
     setTechblogSort('LATEST');
   };

--- a/components/common/searchInput.tsx
+++ b/components/common/searchInput.tsx
@@ -135,7 +135,7 @@ export default function SearchInput() {
   const handleSearch = (curKeyword: string) => {
     const newSortOption = curKeyword === '' ? 'LATEST' : 'HIGHEST_SCORE';
     setIsUserInteraction(true);
-    setCompanyId(undefined);
+    setCompanyId(null);
     if (curKeyword === '') {
       setToastVisible('검색어를 입력해주세요', 'error');
       return;

--- a/constants/TimeConstants.ts
+++ b/constants/TimeConstants.ts
@@ -1,4 +1,7 @@
+// 밀리초 단위
 export const MINUTE = 1000 * 60;
 export const HOUR = MINUTE * 60;
 export const HALF_DAY = HOUR * 12;
 export const DAY = HOUR * 24;
+// 초단위
+export const ONE_DAY_IN_SECONDS = 60 * 60 * 24;

--- a/pages/_app.page.tsx
+++ b/pages/_app.page.tsx
@@ -4,7 +4,7 @@ import { ThemeProvider } from 'next-themes';
 import type { AppProps } from 'next/app';
 import { useRouter } from 'next/router';
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider ,HydrationBoundary } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 import Layout from '@components/common/layout';
@@ -52,11 +52,13 @@ export default function MyApp({ Component, pageProps }: AppProps) {
 
   return (
     <QueryClientProvider client={queryClient}>
+      <HydrationBoundary state={pageProps.dehydratedState}>
       <ThemeProvider enableSystem={false} attribute='class'>
         <Layout>
           <Component {...pageProps} />
         </Layout>
       </ThemeProvider>
+      </HydrationBoundary>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );

--- a/pages/techblog/api/useInfiniteTechBlog.ts
+++ b/pages/techblog/api/useInfiniteTechBlog.ts
@@ -38,7 +38,7 @@ export const getTechBlogData = async ({
 export const useInfiniteTechBlogData = (
   sortOption: TechBlogDropdownProps,
   keyword?: string,
-  companyId?: number,
+  companyId?: number|null,
   size?: number,
 ) => {
   const isValidSortOption = techBlogDropdownOptions.includes(sortOption);

--- a/pages/techblog/api/useInfiniteTechBlog.ts
+++ b/pages/techblog/api/useInfiniteTechBlog.ts
@@ -17,7 +17,6 @@ export const getTechBlogData = async ({
   companyId,
   score,
   size,
-  token
 }: GetTechBlogProps) => {
   const queryParams = {
     size: size ? size : TECH_VIEW_SIZE,
@@ -28,15 +27,12 @@ export const getTechBlogData = async ({
     ...(score && { score }),
   };
 
-  const headers = {
-    ...(token && { 'Authorization': `Bearer ${token}` }), 
-  };
+
 
   const res = await axios.get(`/devdevdev/api/v1/articles?`, {
     params: {
       ...queryParams,
     },
-    headers
   });
   return res.data;
 };

--- a/pages/techblog/api/useInfiniteTechBlog.ts
+++ b/pages/techblog/api/useInfiniteTechBlog.ts
@@ -17,6 +17,7 @@ export const getTechBlogData = async ({
   companyId,
   score,
   size,
+  token
 }: GetTechBlogProps) => {
   const queryParams = {
     size: size ? size : TECH_VIEW_SIZE,
@@ -27,10 +28,15 @@ export const getTechBlogData = async ({
     ...(score && { score }),
   };
 
+  const headers = {
+    ...(token && { 'Authorization': `Bearer ${token}` }), 
+  };
+
   const res = await axios.get(`/devdevdev/api/v1/articles?`, {
     params: {
       ...queryParams,
     },
+    headers
   });
   return res.data;
 };

--- a/pages/techblog/components/searchNotFound.tsx
+++ b/pages/techblog/components/searchNotFound.tsx
@@ -16,7 +16,7 @@ export default function SearchNotFound() {
   const { searchKeyword, setSearchKeyword } = useSearchKeywordStore();
   const handleOnClick = () => {
     setSearchKeyword('');
-    setCompanyId(undefined);
+    setCompanyId(null);
   };
   return (
     <div className='flex flex-col justify-center items-center gap-[3.2rem] pt-[6rem]'>

--- a/pages/techblog/constants/techBlogConstants.ts
+++ b/pages/techblog/constants/techBlogConstants.ts
@@ -1,6 +1,13 @@
+import { TechBlogDropdownProps } from "@stores/dropdownStore";
+
 // 기술블로그 글 조회
 export const TECH_VIEW_SIZE = 10;
 export const MOBILE_MAIN_TECH_VIEW_SIZE = 3;
 
 // 기술블로그 상세 - 댓글조회
 export const TECH_COMMENT_VIEW_SIZE = 10;
+
+// 무한스크롤 파라미터 초깃값
+export const INITIAL_TECH_SORT_OPTION: TechBlogDropdownProps = 'LATEST';
+export const INITIAL_TECH_SEARCH_KEYWORD: string = '';
+export const INITIAL_TECH_COMPANY_ID: number | null = null;

--- a/pages/techblog/index.page.tsx
+++ b/pages/techblog/index.page.tsx
@@ -188,10 +188,6 @@ export async function getStaticProps() {
     };
   } catch (error) {
     console.error('Error prefetching tech blog data:', error);
-    return {
-      props: {
-        dehydratedState: dehydrate(queryClient),
-      },
-    };
+    throw new Error('데이터를 프리패치 하는중 오류가 발생했습니다.');
   }
 }

--- a/pages/techblog/index.page.tsx
+++ b/pages/techblog/index.page.tsx
@@ -22,6 +22,7 @@ import {
 import MetaHead from '@components/meta/MetaHead';
 
 import { techBlogDropdownOptions } from '@/constants/DropdownOptionArr';
+import { ONE_DAY_IN_SECONDS } from '@/constants/TimeConstants';
 import { META } from '@/constants/metaData';
 
 import { useInfiniteTechBlogData, getTechBlogData } from './api/useInfiniteTechBlog';
@@ -184,7 +185,7 @@ export async function getStaticProps() {
       props: {
         dehydratedState: dehydrate(queryClient),
       },
-      revalidate: 60 * 60 * 24, // 페이지를 하루(24시간)마다 다시 생성
+      revalidate: ONE_DAY_IN_SECONDS, // 페이지를 하루(24시간)마다 다시 생성
     };
   } catch (error) {
     console.error('Error prefetching tech blog data:', error);

--- a/pages/techblog/types/techBlogType.ts
+++ b/pages/techblog/types/techBlogType.ts
@@ -7,6 +7,7 @@ export interface GetTechBlogProps {
   companyId?: number|null;
   score?: number;
   size?: number;
+  token?: string;
 }
 
 // 하나의 카드에 필요한 정보

--- a/pages/techblog/types/techBlogType.ts
+++ b/pages/techblog/types/techBlogType.ts
@@ -4,7 +4,7 @@ export interface GetTechBlogProps {
   elasticId?: string;
   techSort: TechBlogDropdownProps;
   keyword?: string;
-  companyId?: number;
+  companyId?: number|null;
   score?: number;
   size?: number;
 }

--- a/pages/techblog/types/techBlogType.ts
+++ b/pages/techblog/types/techBlogType.ts
@@ -1,7 +1,7 @@
 import { TechBlogDropdownProps } from '@stores/dropdownStore';
 
 export interface GetTechBlogProps {
-  elasticId: string;
+  elasticId?: string;
   techSort: TechBlogDropdownProps;
   keyword?: string;
   companyId?: number;

--- a/stores/dropdownStore.ts
+++ b/stores/dropdownStore.ts
@@ -4,6 +4,7 @@ import { MyinfoBookmarkDropdownProps } from '@pages/myinfo/bookmark/bookmarkType
 import { TechBlogCommentsDropdownProps } from '@pages/techblog/types/techCommentsType';
 
 import { TypeBlames } from '@/api/useGetBlames';
+import { INITIAL_TECH_SORT_OPTION } from '@pages/techblog/constants/techBlogConstants';
 
 export type PickDropdownProps = 'POPULAR' | 'LATEST' | 'MOST_VIEWED' | 'MOST_COMMENTED';
 
@@ -40,7 +41,7 @@ const createDropdownStore = (defaultSortOption: DropdownOptionProps) =>
   }));
 
 export const usePickDropdownStore = createDropdownStore('POPULAR');
-export const useTechblogDropdownStore = createDropdownStore('LATEST');
+export const useTechblogDropdownStore = createDropdownStore(INITIAL_TECH_SORT_OPTION);
 
 // 신고하기 드롭다운 데이터 저장 store
 interface SelectedStoreProps {

--- a/stores/techBlogStore.ts
+++ b/stores/techBlogStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { INITIAL_TECH_COMPANY_ID, INITIAL_TECH_SEARCH_KEYWORD } from '@pages/techblog/constants/techBlogConstants';
 
 interface searchKeywordProps {
   searchKeyword: string;
@@ -6,18 +7,18 @@ interface searchKeywordProps {
 }
 /**서버에 보낼 최종 키워드를 관리하는 store*/
 export const useSearchKeywordStore = create<searchKeywordProps>((set) => ({
-  searchKeyword: '',
+  searchKeyword: INITIAL_TECH_SEARCH_KEYWORD,
   setSearchKeyword: (keyword: string) => set({ searchKeyword: keyword }),
 }));
 
 interface companyIdProps {
-  companyId: number | undefined;
-  setCompanyId: (id: number | undefined) => void;
+  companyId: number | null;
+  setCompanyId: (id: number | null) => void;
 }
 /** company id를 저장하고 있는 store */
 export const useCompanyIdStore = create<companyIdProps>((set) => ({
-  companyId: undefined,
-  setCompanyId: (id: number | undefined) => set({ companyId: id }),
+  companyId: INITIAL_TECH_COMPANY_ID,
+  setCompanyId: (id: number | null) => set({ companyId: id }),
 }));
 
 // 기술블로그 댓글 id를 저장하는 store (삭제,신고)


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
- [x] 기술블로그 메인페이지 SSG적용
- 무한스크롤의 첫 페이지를 `getStaticProps`를 사용하여 서버사이드에서 데이터를 불러오도록 최적화
- [x] [무한스크롤 파라미터값 상수화 (초깃값을 쉽게 관리하기 위해) ](https://github.com/dreamyPatisiel/devdevdev-client/pull/197/commits/0de0e4b099db3d8527c4d10eec3f7ecc0cf42075)
## 🔗 참고할만한 자료(선택)
> 슬랙이나 피그마, Jira 등 참고 링크를 첨부해주세요
- [노션 리팩토링 정리자료](https://faceted-noise-b31.notion.site/SSG-15a9898eb0a1808a986fcd0c0db52afc)

## 💬 리뷰 요구사항(선택)
- 점진적으로 SSG나 SSR를 사용했을때 이점이 있는 부분들을 리팩토링 하면 좋을것 같아요~~