### PR TITLE
[hotfix] 댓글 첫 렌더링 시 모바일 드롭다운 setSort

### DIFF
--- a/components/common/dropdowns/mobileDropdown.tsx
+++ b/components/common/dropdowns/mobileDropdown.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import Image from 'next/image';
 
@@ -60,6 +60,12 @@ export default function MobileDropdown({
       dropdownOptions = pickCommentOptions;
       break;
   }
+
+  useEffect(() => {
+    if (!dropdownOptions.includes(sortOption)) {
+      setSort(dropdownOptions[0] as DropdownOptionProps);
+    }
+  }, []);
 
   const handleOptionSelected = (value: DropdownOptionProps) => () => {
     setShowBottom(false);


### PR DESCRIPTION
## 📝 작업 내용
- [x] 댓글 첫 렌더링 시 모바일 드롭다운 setSort 

## 🔗 참고할만한 자료(선택)
[해당 이슈](https://dreamy-patisiel.slack.com/archives/C076TT1ASNB/p1744437280022459) 

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
